### PR TITLE
tweak build.sh and docker compose

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,38 +1,36 @@
 #!/bin/sh
 
-# If the keystore directory doesn't exist, then we should generate
-# the keystores we need for local signed JWTs to work
-if [ ! -d keystore ]
-then
-  echo "Generating key stores"
-  rm -f keystore/key.jks
-  rm -f keystore/public.crt
-  rm -f keystore/truststore.jks
-  mkdir -p keystore
-  keytool -genkey -alias default -storepass testOnlyKeystore -keypass testOnlyKeystore -keystore keystore/key.jks -keyalg RSA -sigalg SHA1withRSA -validity 365 -dname "CN=localcert,OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA"
-  keytool -export -alias default -storepass testOnlyKeystore -keypass testOnlyKeystore -keystore keystore/key.jks -file keystore/public.crt
-  keytool -import -noprompt -alias default -storepass truststore -keypass truststore -keystore keystore/truststore.jks -file keystore/public.crt
-  rm -f keystore/public.crt
-fi
-
 # Support environments with docker-machine
 # For base linux users, 127.0.0.1 is fine, but w/ docker-machine we need to
 # use the host ip instead. So we'll generate an over-ridden env file that
 # will get passed/copied properly into the target servers
-name=${DOCKER_MACHINE_NAME-empty}
-if [ "$name" = "empty" ]
+NAME=${DOCKER_MACHINE_NAME-empty}
+IP=127.0.0.1
+if [ "$NAME" = "empty" ]
 then
   echo "DOCKER_MACHINE_NAME is not set. To avoid warning messages, you might set this to ''."
-elif [ -n $name ]
+elif [ -n $NAME ]
 then
-  if [ ! -f gameon.${name}env ]
+  IP=$(docker-machine ip $NAME)
+  if [ ! -f gameon.${NAME}env ]
   then
-      IP=$(docker-machine ip $name)
-    echo "Creating new environment file gameon.${name}env to contain environment variable overrides.
-This file will use the docker host ip address ($IP). 
+    echo "Creating new environment file gameon.${NAME}env to contain environment variable overrides.
+This file will use the docker host ip address ($IP).
 When the docker containers are up, use https://$IP/ to connect to the game."
-    sed -e "s#127.\0.\0\.1#${IP}#g" gameon.env > gameon.${name}env
+    sed -e "s#127.\0.\0\.1#${IP}#g" gameon.env > gameon.${NAME}env
   fi
+fi
+
+# If the keystore directory doesn't exist, then we should generate
+# the keystores we need for local signed JWTs to work
+if [ ! -d keystore ]
+then
+  echo "Generating key stores using ${IP}"
+  mkdir -p keystore
+  keytool -genkey -alias default -storepass testOnlyKeystore -keypass testOnlyKeystore -keystore keystore/key.jks -keyalg RSA -sigalg SHA1withRSA -validity 365 -dname "CN=${IP},OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA"
+  keytool -export -alias default -storepass testOnlyKeystore -keypass testOnlyKeystore -keystore keystore/key.jks -file keystore/public.crt
+  keytool -import -noprompt -alias default -storepass truststore -keypass truststore -keystore keystore/truststore.jks -file keystore/public.crt
+  rm -f keystore/public.crt
 fi
 
 for SUBDIR in *
@@ -44,3 +42,10 @@ do
     cd ..
   fi
 done
+
+echo "
+If all of that went well, remember to re-spin your docker containers:
+ docker-compose build
+ docker-compose up
+
+The game will be running at https://${IP}/ when you're all done."

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,3 +21,7 @@ mediator:
     - '$HOME:$HOME'
     - './mediator/mediator-wlpcfg/servers/gameon-mediator:/opt/ibm/wlp/usr/servers/defaultServer'
     - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+
+webapp:
+  volumes:
+    - './webapp/src:/opt/www'


### PR DESCRIPTION
update build.sh to get the IP address of the docker host (if present) and use that when creating the keystores that are used for JWT validation in the local environment. Also added some more helpful output messages that describe what it is doing and what should be done next.

Update to docker-compose.override.yml to also map in the webapp src directory so that changes to the webapp can be made without having to restart that container.