### PR TITLE
Add new auth project to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,17 @@ webapp:
   - "8080:8080"
  env_file: gameon.${DOCKER_MACHINE_NAME}env
 
+auth:
+ build: auth/auth-wlpcfg
+ volumes:
+  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+ links:
+  - kafka
+ ports:
+  - "9089:9080"
+  - "9449:9443"
+ env_file: gameon.${DOCKER_MACHINE_NAME}env
+
 player:
  # build: player/player-wlpcfg
  image: gameontext/gameon-player
@@ -65,6 +76,7 @@ proxy:
  image: gameontext/gameon-proxy
  env_file: gameon.${DOCKER_MACHINE_NAME}env
  links:
+  - auth
   - webapp
   - player
   - room

--- a/gameon.env
+++ b/gameon.env
@@ -9,8 +9,8 @@ CONCIERGE_KEY=Wibble
 REGISTRATION_SECRET=MyRegistrationSecret
 QUERY_SECRET=MyQuerySecret
 MAP_URL=http://map:9080/map/v1/sites
-MAP_PLAYER_URL=https://player:9443/play/players
-MEDIATOR_PLAYER_URL=https://player:9443/play/players
+MAP_PLAYER_URL=https://player:9443/players/v1/accounts
+MEDIATOR_PLAYER_URL=https://player:9443/players/v1/accounts
 MAP_PLAYER_MODE=development
 MAP_KEY=fish
 #
@@ -24,7 +24,7 @@ COUCHDB_URL=http://couchdb:5984
 COUCHDB_USER=mapUser
 COUCHDB_PASSWORD=myCouchDBSecret
 #
-PLAYER_URL=https://127.0.0.1/play/players
+PLAYER_URL=https://127.0.0.1/players/v1/accounts
 MONGO_HOST=mongo
 MONGO_PORT=27017
 TWITTER_CONSUMER_KEY=

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'gameon'
 
+include 'auth:auth-app'
+include 'auth:auth-wlpcfg'
 include 'player:player-app'
 include 'player:player-wlpcfg'
 include 'map:map-app'


### PR DESCRIPTION
We can merge this one as soon as gameon-auth becomes a submodule of this repo, it's not bound by needing the auth pipeline to be complete.. it just adds the auth project to the root gradle & docker-compose. (I don't know how to add it as submodule at the mo.. I guess maybe that should be done as part of this PR?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/30)
<!-- Reviewable:end -->
