### PR TITLE
Set couch level explicitly

### DIFF
--- a/platformservices.yml
+++ b/platformservices.yml
@@ -93,7 +93,7 @@ gateway:
 
 ########CouchDB##################
 couchdb:
- image: klaemo/couchdb:latest
+ image: klaemo/couchdb:1.6.1
  ports:
   - "5984:5984"
  container_name: couchdb


### PR DESCRIPTION
Couch latest moved _config endpoint to a new port, which breaks our map
setup script. Setting couch to use 1.6.1 for now locally to fix this.
Signed-off-by: Ozzy Osborne <ozzy@ca.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/49)
<!-- Reviewable:end -->
