### PR TITLE
Fix docker machine setup

### DIFF
--- a/go-setup.sh
+++ b/go-setup.sh
@@ -34,7 +34,7 @@ then
 This file will use the docker host ip address ($IP).
 When the docker containers are up, use https://$IP/ to connect to the game."
   fi
-  sed -e "s#127.\0.\0\.1#${IP}#g" gameon.env > gameon.${NAME}env
+  cat gameon.env | sed  -e "s#127\.0\.0\.1\:6379#A8LOCALHOSTPRESERVE#g" | sed -e "s#127\.0\.0\.1#${IP}#g" | sed -e "s#A8LOCALHOSTPRESERVE#127\.0\.0\.1#" > gameon.${NAME}env
 fi
 
 # If the keystore directory doesn't exist, then we should generate

--- a/go-setup.sh
+++ b/go-setup.sh
@@ -34,7 +34,7 @@ then
 This file will use the docker host ip address ($IP).
 When the docker containers are up, use https://$IP/ to connect to the game."
   fi
-  cat gameon.env | sed  -e "s#127\.0\.0\.1\:6379#A8LOCALHOSTPRESERVE#g" | sed -e "s#127\.0\.0\.1#${IP}#g" | sed -e "s#A8LOCALHOSTPRESERVE#127\.0\.0\.1#" > gameon.${NAME}env
+  cat gameon.env | sed  -e "s#127\.0\.0\.1\:6379#A8LOCALHOSTPRESERVE#g" | sed -e "s#127\.0\.0\.1#${IP}#g" | sed -e "s#A8LOCALHOSTPRESERVE#127\.0\.0\.1\:6379#" > gameon.${NAME}env
 fi
 
 # If the keystore directory doesn't exist, then we should generate


### PR DESCRIPTION
We shouldn't convert instances of the in-container a8 proxy to be docker host. 
Oops. 

Ideally I'd use a negative lookahead regex here, but sed doesn't support those, so rather than introduce a dependency on perl, I just sed the proxy instances to a 'safe' value, then do the regular replace, then swap the safe value back.. simples!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/55)
<!-- Reviewable:end -->
