### PR TITLE
Generate keystore in a container in to a volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .gradle
-keystore
 gameon.devenv
 gameon.defaultenv
 docker-compose.override.yml
-setup-utils

--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ Using the [map project](https://github.com/gameontext/gameon-map) as an example,
 2. Re-enable the build directive in the docker-compose.yml file and comment out the image directive.
   ```
   map:
-   build: map/map-wlpcfg
+   build:
+     context:  map/map-wlpcfg
   #image: gameontext/gameon-map
    volumes:
-    - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
   ```
 
 3. Build the project(s) (includes building wars and creating keystores

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,38 +1,53 @@
-auth:
-  build: auth/auth-wlpcfg
+version: '2'
 
-map:
-  build: map/map-wlpcfg
-  volumes:
-    - '$HOME:$HOME'
-    - './map/map-wlpcfg/servers/gameon-map:/opt/ibm/wlp/usr/servers/defaultServer'
-    - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+services:
 
-mediator:
-  build: mediator/mediator-wlpcfg
-  volumes:
-    - '$HOME:$HOME'
-    - './mediator/mediator-wlpcfg/servers/gameon-mediator:/opt/ibm/wlp/usr/servers/defaultServer'
-    - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+  auth:
+    build:
+      context: auth/auth-wlpcfg
+  
+  map:
+    build:
+      context: map/map-wlpcfg
+    volumes:
+      - '$HOME:$HOME'
+      - './map/map-wlpcfg/servers/gameon-map:/opt/ibm/wlp/usr/servers/defaultServer'
+      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+  
+  mediator:
+    build:
+      context: mediator/mediator-wlpcfg
+    volumes:
+      - '$HOME:$HOME'
+      - './mediator/mediator-wlpcfg/servers/gameon-mediator:/opt/ibm/wlp/usr/servers/defaultServer'
+      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+  
+  player:
+    build:
+      context: player/player-wlpcfg
+    volumes:
+      - '$HOME:$HOME'
+      - './player/player-wlpcfg/servers/gameon-player:/opt/ibm/wlp/usr/servers/defaultServer'
+      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+  
+  proxy:
+    build:
+      context: proxy
+  
+  room:
+    build:
+      context: room/room-wlpcfg
+    volumes:
+      - '$HOME:$HOME'
+      - './room/room-wlpcfg/servers/gameon-room:/opt/ibm/wlp/usr/servers/defaultServer'
+      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+  
+  webapp:
+    build:
+      context: webapp
+    volumes:
+      - './webapp/src:/opt/www'
 
-player:
-  build: player/player-wlpcfg
-  volumes:
-    - '$HOME:$HOME'
-    - './player/player-wlpcfg/servers/gameon-player:/opt/ibm/wlp/usr/servers/defaultServer'
-    - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
-
-proxy:
-  build: proxy
-
-room:
-  build: room/room-wlpcfg
-  volumes:
-    - '$HOME:$HOME'
-    - './room/room-wlpcfg/servers/gameon-room:/opt/ibm/wlp/usr/servers/defaultServer'
-    - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
-
-webapp:
-  build: webapp
-  volumes:
-    - './webapp/src:/opt/www'
+volumes:
+  keystore:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,107 +10,122 @@
 ## (urls for a8 are set within the gameon.env file, assuming
 ##  these external links are present)
 
-auth:
- #build: auth/auth-wlpcfg
- image: gameontext/gameon-auth
- volumes:
-  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
- external_links:
-  - kafka
-  - registry
-  - logstash
-  - controller
- ports:
-  - "9089:9080"
-  - "9449:9443"
- env_file: gameon.${DOCKER_MACHINE_NAME}env
+version: '2'
 
-player:
- #build: player/player-wlpcfg
- image: gameontext/gameon-player
- volumes:
-  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
- external_links:
-  - couchdb
-  - kafka
-  - registry
-  - logstash
-  - controller
- ports:
-  - "4201:4201"
-  - "9082:9080"
-  - "9443:9443"
- env_file: gameon.${DOCKER_MACHINE_NAME}env
+services:
 
-map:
- #build: map/map-wlpcfg
- image: gameontext/gameon-map
- volumes:
-  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
- external_links:
-  - couchdb
-  - kafka
-  - registry
-  - logstash
-  - controller
- ports:
-  - "9099:9080"
-  - "9447:9443"
- env_file: gameon.${DOCKER_MACHINE_NAME}env
+  auth:
+   #build:
+   #  context: auth/auth-wlpcfg
+   image: gameontext/gameon-auth
+   volumes:
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+   external_links:
+    - kafka
+    - registry
+    - logstash
+    - controller
+   ports:
+    - "9089:9080"
+    - "9449:9443"
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+  
+  player:
+   #build:
+   #  context: player/player-wlpcfg
+   image: gameontext/gameon-player
+   volumes:
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+   external_links:
+    - couchdb
+    - kafka
+    - registry
+    - logstash
+    - controller
+   ports:
+    - "4201:4201"
+    - "9082:9080"
+    - "9443:9443"
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+  
+  map:
+   #build:
+   #  context: map/map-wlpcfg
+   image: gameontext/gameon-map
+   volumes:
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+   external_links:
+    - couchdb
+    - kafka
+    - registry
+    - logstash
+    - controller
+   ports:
+    - "9099:9080"
+    - "9447:9443"
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+  
+  mediator:
+   #build:
+   #  context: mediator/mediator-wlpcfg
+   image: gameontext/gameon-mediator
+   volumes:
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+   ports:
+    - "9086:9080"
+    - "9446:9443"
+   links:
+    - room
+   external_links:
+    - kafka
+    - registry
+    - logstash
+    - controller
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+  
+  proxy:
+   #build:
+   #  context: proxy
+   image: gameontext/gameon-proxy
+   volumes:
+    - 'keystore:/keystore'
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+   links:
+    - webapp
+    - room
+   external_links:
+    - kafka
+    - registry
+    - logstash
+    - controller
+   ports:
+    - "80:80"
+    - "443:443"
+    - "1936:1936"
+  
+  webapp:
+   #build:
+   #  context: webapp
+   image: gameontext/gameon-webapp
+   ports:
+    - "8080:8080"
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
+  
+  room:
+   #build:
+   #  context: room/room-wlpcfg
+   image: gameontext/gameon-room
+   volumes:
+    - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
+   links:
+    - map
+   external_links:
+    - kafka
+   ports:
+    - "9080:9080"
+    - "9445:9443"
+   env_file: gameon.${DOCKER_MACHINE_NAME}env
 
-mediator:
- #build: mediator/mediator-wlpcfg
- image: gameontext/gameon-mediator
- volumes:
-  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
- ports:
-  - "9086:9080"
-  - "9446:9443"
- links:
-  - room
- external_links:
-  - kafka
-  - registry
-  - logstash
-  - controller
- env_file: gameon.${DOCKER_MACHINE_NAME}env
-
-proxy:
- #build: proxy
- image: gameontext/gameon-proxy
- volumes:
-  - './keystore:/keystore'
- env_file: gameon.${DOCKER_MACHINE_NAME}env
- links:
-  - webapp
-  - room
- external_links:
-  - kafka
-  - registry
-  - logstash
-  - controller
- ports:
-  - "80:80"
-  - "443:443"
-  - "1936:1936"
-
-webapp:
- #build: webapp
- image: gameontext/gameon-webapp
- ports:
-  - "8080:8080"
- env_file: gameon.${DOCKER_MACHINE_NAME}env
-
-room:
- #build: room/room-wlpcfg
- image: gameontext/gameon-room
- volumes:
-  - './keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
- links:
-  - map
- external_links:
-  - kafka
- ports:
-  - "9080:9080"
-  - "9445:9443"
- env_file: gameon.${DOCKER_MACHINE_NAME}env
+volumes:
+  keystore:
+    external: true

--- a/gen-keystore.sh
+++ b/gen-keystore.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# Generate keystores in ./keystore for a given IP
+
+if (( $# != 1))
+then
+  echo "Usage: ./gen-keystore.sh <IP>"
+  exit 1
+fi
+
+IP=$1
+
+if [ -z ${JAVA_HOME} ]
+then
+  echo "JAVA_HOME is not set. Please set and re-run this script."
+  exit 1
+fi
+
+echo "Checking for keytool..."
+keytool -help > /dev/null 2>&1
+if [ $? != 0 ]
+then
+  echo "Error: keytool is missing from the path, please correct this, then retry"
+  exit 1
+fi
+
+echo "Building pem extractor"
+mkdir -p setup-utils
+
+#HAProxy will need the private key in PEM format, but keytool
+# only allows us to save private keys in pkcs12, thankfully java
+# is pretty easy to use to create us a tool to export private keys
+# in PEM format.. so we'll just inline a small bit here to let us
+# do that later.
+# (Yes, you can do this with openssl, but we don't have that as a prereq)
+cat > setup-utils/PemExporter.java << 'EOT'
+  import java.util.*;
+  import java.io.*;
+  import java.security.*;
+
+  public class PemExporter
+  {
+      private File keystoreFile;
+      private String keyStoreType;
+      private char[] keyStorePassword;
+      private char[] keyPassword;
+      private String alias;
+      private File exportedFile;
+      private static final byte[] CRLF = new byte[] {'\r', '\n'};
+
+      public void export() throws Exception {
+          KeyStore keystore = KeyStore.getInstance(keyStoreType);
+          keystore.load(new FileInputStream(keystoreFile), keyStorePassword);
+          Key key = keystore.getKey(alias, keyPassword);
+          String encoded = Base64.getMimeEncoder(64,CRLF).encodeToString(key.getEncoded());
+          FileWriter fw = new FileWriter(exportedFile);
+          fw.write("-----BEGIN PRIVATE KEY-----\n");
+          fw.write(encoded);
+          fw.write("\n");
+          fw.write("-----END PRIVATE KEY-----");
+          fw.close();
+      }
+
+      public static void main(String args[]) throws Exception {
+          PemExporter export = new PemExporter();
+          export.keystoreFile = new File(args[0]);
+          export.keyStoreType = args[1];
+          export.keyStorePassword = args[2].toCharArray();
+          export.alias = args[3];
+          export.keyPassword = args[4].toCharArray();
+          export.exportedFile = new File(args[5]);
+          export.export();
+      }
+  }
+EOT
+cd setup-utils
+javac PemExporter.java
+if [ $? != 0 ]
+then
+  echo "Error: failed to compile the certificate exported"
+  exit 1
+fi
+cd ..
+
+echo "Generating key stores using ${IP}"
+
+#create a ca cert we'll import into all our trust stores..
+keytool -genkeypair \
+  -alias gameonca \
+  -keypass gameonca \
+  -storepass gameonca \
+  -keystore keystore/cakey.jks \
+  -keyalg RSA \
+  -keysize 2048 \
+  -dname "CN=GameOnLocalDevCA, OU=The Amazing GameOn Certificate Authority, O=The Ficticious GameOn Company, L=Earth, ST=Happy, C=CA" \
+  -ext KeyUsage="keyCertSign" \
+  -ext BasicConstraints:"critical=ca:true" \
+  -validity 9999
+#export the ca cert so we can add it to the trust stores
+keytool -exportcert \
+  -alias gameonca \
+  -keypass gameonca \
+  -storepass gameonca \
+  -keystore keystore/cakey.jks \
+  -file keystore/gameonca.crt \
+  -rfc
+#create the keypair we plan to use for our ssl/jwt signing
+keytool -genkeypair \
+  -alias gameonappkey \
+  -keypass testOnlyKeystore \
+  -storepass testOnlyKeystore \
+  -keystore keystore/key.jks \
+  -keyalg RSA \
+  -sigalg SHA1withRSA \
+  -dname "CN=${IP},OU=GameOn Application,O=The Ficticious GameOn Company,L=Earth,ST=Happy,C=CA" \
+  -validity 365
+#create the signing request for the app key
+keytool -certreq \
+  -alias gameonappkey \
+  -keypass testOnlyKeystore \
+  -storepass testOnlyKeystore \
+  -keystore keystore/key.jks \
+  -file keystore/appsignreq.csr
+#sign the cert with the ca
+keytool -gencert \
+  -alias gameonca \
+  -keypass gameonca \
+  -storepass gameonca \
+  -keystore keystore/cakey.jks \
+  -infile keystore/appsignreq.csr \
+  -outfile keystore/app.cer
+#import the ca cert
+keytool -importcert \
+  -alias gameonca \
+  -storepass testOnlyKeystore \
+  -keypass testOnlyKeystore \
+  -keystore keystore/key.jks \
+  -noprompt \
+  -file keystore/gameonca.crt
+#import the signed cert
+keytool -importcert \
+  -alias gameonappkey \
+  -storepass testOnlyKeystore \
+  -keypass testOnlyKeystore \
+  -keystore keystore/key.jks \
+  -noprompt \
+  -file keystore/app.cer
+#change the alias of the signed cert
+keytool -changealias \
+  -alias gameonappkey \
+  -destalias default \
+  -storepass testOnlyKeystore \
+  -keypass testOnlyKeystore \
+  -keystore keystore/key.jks
+#export the signed cert in pem format for proxy to use
+keytool -exportcert \
+  -alias default \
+  -storepass testOnlyKeystore \
+  -keypass testOnlyKeystore \
+  -keystore keystore/key.jks \
+  -file keystore/app.pem \
+  -rfc
+#export the private key in pem format for proxy to use
+$JAVA_HOME/bin/java -cp setup-utils PemExporter\
+  keystore/key.jks \
+  JCEKS \
+  testOnlyKeystore \
+  default \
+  testOnlyKeystore \
+  keystore/private.pem
+#concat the public and private key for haproxy
+cat keystore/app.pem keystore/private.pem > keystore/proxy.pem
+#add the cacert to the truststore
+keytool -importcert \
+  -alias gameonca \
+  -storepass truststore \
+  -keypass truststore \
+  -keystore keystore/truststore.jks \
+  -noprompt \
+  -trustcacerts \
+  -file keystore/gameonca.crt
+#add all jvm cacerts to the truststore.
+keytool -importkeystore \
+  -srckeystore $JAVA_HOME/lib/security/cacerts \
+  -destkeystore keystore/truststore.jks \
+  -srcstorepass changeit \
+  -deststorepass truststore
+#clean up the public cert..
+rm -f keystore/public.crt

--- a/go-setup.sh
+++ b/go-setup.sh
@@ -11,12 +11,6 @@
 # One-time, initial setup
 #
 
-if [ -z ${JAVA_HOME} ]
-then
-  echo "JAVA_HOME is not set. Please set and re-run this script."
-  exit 1
-fi
-
 NAME=${DOCKER_MACHINE_NAME-empty}
 IP=127.0.0.1
 if [ "$NAME" = "empty" ]
@@ -47,188 +41,20 @@ fi
 # the keystores we need for local signed JWTs to work
 if [ ! -d keystore ]
 then
-  echo "Checking for keytool..."
-  keytool -help > /dev/null 2>&1
-  if [ $? != 0 ]
+  mkdir keystore
+
+  #check for selinux by looking for chcon and sestatus..
+  #needed for fedora else the keystore dirs cannot be mapped in by
+  #docker-compose volume mapping
+  if [ -x "$(type -P chcon)" ] && [ -x "$(type -P sestatus)" ]
   then
-     echo "Error: keytool is missing from the path, please correct this, then retry"
-	 exit 1
+    echo ""
+    echo "SELinux detected, adding svirt_sandbox_file_t to keystore dir"
+    chcon -Rt svirt_sandbox_file_t ./keystore
   fi
 
-  echo "Building pem extractor"
-  mkdir -p setup-utils
-
-  #HAProxy will need the private key in PEM format, but keytool
-  # only allows us to save private keys in pkcs12, thankfully java
-  # is pretty easy to use to create us a tool to export private keys
-  # in PEM format.. so we'll just inline a small bit here to let us
-  # do that later.
-  # (Yes, you can do this with openssl, but we don't have that as a prereq)
-cat > setup-utils/PemExporter.java << 'EOT'
-  import java.util.*;
-  import java.io.*;
-  import java.security.*;
-
-  public class PemExporter
-  {
-      private File keystoreFile;
-      private String keyStoreType;
-      private char[] keyStorePassword;
-      private char[] keyPassword;
-      private String alias;
-      private File exportedFile;
-      private static final byte[] CRLF = new byte[] {'\r', '\n'};
-
-      public void export() throws Exception {
-          KeyStore keystore = KeyStore.getInstance(keyStoreType);
-          keystore.load(new FileInputStream(keystoreFile), keyStorePassword);
-          Key key = keystore.getKey(alias, keyPassword);
-          String encoded = Base64.getMimeEncoder(64,CRLF).encodeToString(key.getEncoded());
-          FileWriter fw = new FileWriter(exportedFile);
-          fw.write("-----BEGIN PRIVATE KEY-----\n");
-          fw.write(encoded);
-          fw.write("\n");
-          fw.write("-----END PRIVATE KEY-----");
-          fw.close();
-      }
-
-      public static void main(String args[]) throws Exception {
-          PemExporter export = new PemExporter();
-          export.keystoreFile = new File(args[0]);
-          export.keyStoreType = args[1];
-          export.keyStorePassword = args[2].toCharArray();
-          export.alias = args[3];
-          export.keyPassword = args[4].toCharArray();
-          export.exportedFile = new File(args[5]);
-          export.export();
-      }
-  }
-EOT
-  cd setup-utils
-  $JAVA_HOME/bin/javac PemExporter.java
-  if [ $? != 0 ]
-  then
-     echo "Error: failed to compile the certificate exported"
-   exit 1
-  fi
-  cd ..
-
-  echo "Generating key stores using ${IP}"
-  #create the keystore dir.. (we're only here if it doesn't exist!)
-  mkdir -p keystore
-  #create a ca cert we'll import into all our trust stores..
-  keytool -genkeypair \
-    -alias gameonca \
-    -keypass gameonca \
-    -storepass gameonca \
-    -keystore keystore/cakey.jks \
-    -keyalg RSA \
-    -keysize 2048 \
-    -dname "CN=GameOnLocalDevCA, OU=The Amazing GameOn Certificate Authority, O=The Ficticious GameOn Company, L=Earth, ST=Happy, C=CA" \
-    -ext KeyUsage="keyCertSign" \
-    -ext BasicConstraints:"critical=ca:true" \
-    -validity 9999
-  #export the ca cert so we can add it to the trust stores
-  keytool -exportcert \
-    -alias gameonca \
-    -keypass gameonca \
-    -storepass gameonca \
-    -keystore keystore/cakey.jks \
-    -file keystore/gameonca.crt \
-    -rfc
-  #create the keypair we plan to use for our ssl/jwt signing
-  keytool -genkeypair \
-    -alias gameonappkey \
-    -keypass testOnlyKeystore \
-    -storepass testOnlyKeystore \
-    -keystore keystore/key.jks \
-    -keyalg RSA \
-    -sigalg SHA1withRSA \
-    -dname "CN=${IP},OU=GameOn Application,O=The Ficticious GameOn Company,L=Earth,ST=Happy,C=CA" \
-    -validity 365
-  #create the signing request for the app key
-  keytool -certreq \
-    -alias gameonappkey \
-    -keypass testOnlyKeystore \
-    -storepass testOnlyKeystore \
-    -keystore keystore/key.jks \
-    -file keystore/appsignreq.csr
-  #sign the cert with the ca
-  keytool -gencert \
-    -alias gameonca \
-    -keypass gameonca \
-    -storepass gameonca \
-    -keystore keystore/cakey.jks \
-    -infile keystore/appsignreq.csr \
-    -outfile keystore/app.cer
-  #import the ca cert
-  keytool -importcert \
-    -alias gameonca \
-    -storepass testOnlyKeystore \
-    -keypass testOnlyKeystore \
-    -keystore keystore/key.jks \
-    -noprompt \
-    -file keystore/gameonca.crt
-  #import the signed cert
-  keytool -importcert \
-    -alias gameonappkey \
-    -storepass testOnlyKeystore \
-    -keypass testOnlyKeystore \
-    -keystore keystore/key.jks \
-    -noprompt \
-    -file keystore/app.cer
-  #change the alias of the signed cert
-  keytool -changealias \
-    -alias gameonappkey \
-    -destalias default \
-    -storepass testOnlyKeystore \
-    -keypass testOnlyKeystore \
-    -keystore keystore/key.jks
-  #export the signed cert in pem format for proxy to use
-  keytool -exportcert \
-  -alias default \
-  -storepass testOnlyKeystore \
-  -keypass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -file keystore/app.pem \
-  -rfc
-  #export the private key in pem format for proxy to use
-  $JAVA_HOME/bin/java -cp setup-utils PemExporter\
-   keystore/key.jks \
-   JCEKS \
-   testOnlyKeystore \
-   default \
-   testOnlyKeystore \
-   keystore/private.pem
-  #concat the public and private key for haproxy
-  cat keystore/app.pem keystore/private.pem > keystore/proxy.pem
-  #add the cacert to the truststore
-  keytool -importcert \
-    -alias gameonca \
-    -storepass truststore \
-    -keypass truststore \
-    -keystore keystore/truststore.jks \
-    -noprompt \
-    -trustcacerts \
-    -file keystore/gameonca.crt
-  #add all jvm cacerts to the truststore.
-  keytool -importkeystore \
-    -srckeystore $JAVA_HOME/jre/lib/security/cacerts \
-    -destkeystore keystore/truststore.jks \
-    -srcstorepass changeit \
-    -deststorepass truststore
-  #clean up the public cert..
-  rm -f keystore/public.crt
-fi
-
-#check for selinux by looking for chcon and sestatus..
-#needed for fedora else the keystore dirs cannot be mapped in by
-#docker-compose volume mapping
-if [ -x "$(type -P chcon)" ] && [ -x "$(type -P sestatus)" ]
-then
-  echo ""
-  echo "SELinux detected, adding svirt_sandbox_file_t to keystore dir"
-  chcon -Rt svirt_sandbox_file_t ./keystore
+  # Generate keystore
+  docker run -v $(pwd):/host -w /host -it ibmjava:sdk ./gen-keystore.sh ${IP}
 fi
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/platformservices.yml
+++ b/platformservices.yml
@@ -14,100 +14,103 @@
 
 ## GameOn Local Platform Services ## 
 
+version: '2'
+
+services:
+
 ###############Integration Bus############
-kafka:
-  image: rshriram/kafka-0.9
-  environment:
-    - ADVERTISED_HOST=kafka
-    - ADVERTISED_PORT=9092
-    - AUTO_CREATE_TOPICS=true
-  ports:
-    - "9092:9092"
-  hostname: kafka
-  container_name: kafka
-
+  kafka:
+    image: rshriram/kafka-0.9
+    environment:
+      - ADVERTISED_HOST=kafka
+      - ADVERTISED_PORT=9092
+      - AUTO_CREATE_TOPICS=true
+    ports:
+      - "9092:9092"
+    hostname: kafka
+    container_name: kafka
+  
 ##########ELK Stack##############
-es:
-  image: elasticsearch
-  ports:
-    - 9300
-    - "30200:9200"
-  container_name: elasticsearch
-logstash:
-  image: logstash
-  command: logstash --verbose -e "input { beats {codec=>'json' port=>8092}} output {elasticsearch {hosts =>'es:9200' codec=>'json'} }"
-  ports:
-    - "8092:8092"
-  links:
-    - es
-  container_name: logstash
-kibana:
-  image: kibana
-  links:
-    - es
-  environment:
-    - ELASTICSEARCH_URL=http://es:9200
-  ports:
-    - "30500:5601"
-  container_name: kibana
-
+  es:
+    image: elasticsearch
+    ports:
+      - 9300
+      - "30200:9200"
+    container_name: elasticsearch
+  logstash:
+    image: logstash
+    command: logstash --verbose -e "input { beats {codec=>'json' port=>8092}} output {elasticsearch {hosts =>'es:9200' codec=>'json'} }"
+    ports:
+      - "8092:8092"
+    links:
+      - es
+    container_name: logstash
+  kibana:
+    image: kibana
+    links:
+      - es
+    environment:
+      - ELASTICSEARCH_URL=http://es:9200
+    ports:
+      - "30500:5601"
+    container_name: kibana
+  
 #######A8 Control Plane###########
-
-registry:
-  image: amalgam8/a8-registry
-  ports:
-    - "31300:8080"
-  container_name: registry
-  environment:
-    - A8_STORE=redis
-    - A8_STORE_ADDRESS=redis:6379
-  links:
-    - redis
-
-controller:
-  image: amalgam8/a8-controller
-  ports:
-    - "31200:8080"
-  environment:
-    - A8_LOG_LEVEL=info
-    - A8_DATABASE_TYPE=redis
-    - A8_DATABASE_HOST=redis://redis:6379
-  links:
-    - redis
-  container_name: controller
-
+  
+  registry:
+    image: amalgam8/a8-registry
+    ports:
+      - "31300:8080"
+    container_name: registry
+    environment:
+      - A8_STORE=redis
+      - A8_STORE_ADDRESS=redis:6379
+    links:
+      - redis
+  
+  controller:
+    image: amalgam8/a8-controller
+    ports:
+      - "31200:8080"
+    environment:
+      - A8_LOG_LEVEL=info
+      - A8_DATABASE_TYPE=redis
+      - A8_DATABASE_HOST=redis://redis:6379
+    links:
+      - redis
+    container_name: controller
+  
 #Redis Backend
-redis:
-  image: redis:alpine
-  ports:
-    - "31400:6379"
-  container_name: redis
-
+  redis:
+    image: redis:alpine
+    ports:
+      - "31400:6379"
+    container_name: redis
+  
 ########Gateway##################
-gateway:
-  image: amalgam8/a8-sidecar:0.3-alpine
-  environment:
-    - A8_CONTROLLER_URL=http://controller:8080
-    - A8_REGISTRY_URL=http://registry:8080
-    - A8_PROXY=true
-    - A8_LOG=true
-    - A8_SERVICE=gateway
-    - A8_LOGSTASH_SERVER='logstash:8092'
-    - A8_CONTROLLER_POLL=5s
-    - A8_REGISTRY_POLL=5s
-  ports:
-    - "32000:6379"
-  links:
-    - logstash
-    - controller
-    - registry
-  container_name: gateway
-
+  gateway:
+    image: amalgam8/a8-sidecar:0.3-alpine
+    environment:
+      - A8_CONTROLLER_URL=http://controller:8080
+      - A8_REGISTRY_URL=http://registry:8080
+      - A8_PROXY=true
+      - A8_LOG=true
+      - A8_SERVICE=gateway
+      - A8_LOGSTASH_SERVER='logstash:8092'
+      - A8_CONTROLLER_POLL=5s
+      - A8_REGISTRY_POLL=5s
+    ports:
+      - "32000:6379"
+    links:
+      - logstash
+      - controller
+      - registry
+    container_name: gateway
+  
 ########CouchDB##################
-couchdb:
- image: klaemo/couchdb:1.6.1
- ports:
-  - "5984:5984"
- container_name: couchdb
-
+  couchdb:
+   image: klaemo/couchdb:1.6.1
+   ports:
+    - "5984:5984"
+   container_name: couchdb
 


### PR DESCRIPTION
Moves generation of the keystore in to a container running the ibmjava image (which has openssl so I've also removed the PemExporter). The keystore is written to a Docker volume rather than the host filesystem and mounted in to the core containers. See comments in the last of the three commits regarding the limited testing for these changes.

Fixes #60 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/69)
<!-- Reviewable:end -->
