### PR TITLE
Set vagrant name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+#default all text to auto convert linefeeds.
+* text=auto
+
+#keep .sh as unix
+*.sh text eol=lf
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,8 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-16.04"
+  config.vm.define "gameontext" do |vm|
+  end
   config.vm.provider "virtualbox" do |v|
     v.memory = 3072
     v.cpus = 2

--- a/bin/.gitattributes
+++ b/bin/.gitattributes
@@ -1,0 +1,3 @@
+#keep all scripts in bin as unix
+* text eol=lf
+

--- a/docker/.gitattributes
+++ b/docker/.gitattributes
@@ -1,0 +1,7 @@
+#default all text to auto convert linefeeds.
+* text=auto
+
+#keep .sh as unix
+*.sh text eol=lf
+docker-functions text eol=lf
+


### PR DESCRIPTION
Without this, vagrant still refers to the vm as 'default'

I only hit this because I was trying to run multiple copies of game on locally inside vagrant, and needed to distinguish them.

To run multiples locally, you also have to manually edit the 2 port mappings to map to known empty ports, else they will conflict with each other

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/110)
<!-- Reviewable:end -->
