### PR TITLE
Add couch host and port for setup usage

### DIFF
--- a/gameon.env
+++ b/gameon.env
@@ -5,6 +5,7 @@ MAP_HEALTH_SERVICE_URL=http://map:9080/map/v1/health
 PLAYER_SERVICE_URL=http://player:9080/players/v1/accounts
 RECROOM_SERVICE_URL=ws://room:9080/rooms
 COUCHDB_SERVICE_URL=http://couchdb:5984
+COUCHDB_HOST_AND_PORT=couchdb:5984
 KAFKA_SERVICE_URL=kafka:9092
 
 #Urls used by the web browser to access Game On!


### PR DESCRIPTION
development mode startup.sh scripts for couch today in player/map build an auth url to couchdb assuming the couch host will always be called couchdb and at the known port. This change adds that information to the main gameon.env so the scripts can stop making that assumption, allowing the host & port to be define as required per runtime environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/114)
<!-- Reviewable:end -->
