### PR TITLE
Add in room service and modify yaml resources

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,100 @@
+# Deploy in IBM Cloud Kubernetes
+
+## Create Namespace and certificates
+
+```
+kubectl create namespace gameon-system
+
+openssl req -x509 -newkey rsa:4096 -keyout ./onlykey.pem -out ./onlycert.pem -days 365 -nodes
+cat ./onlycert.pem ./onlykey.pem > ./cert.pem
+rm ./onlycert.pem ./onlykey.pem
+kubectl create secret generic --namespace=gameon-system --from-file=./cert.pem global-cert
+```
+
+## Modify ingress.yaml and gameon-configmap.yaml
+
+* Get **Ingress subdomain** and **Ingress secret**
+
+```
+bx cs cluster-get <your-cluster-name>
+```
+
+You should get something like this:
+
+<pre>
+Retrieving cluster anthony-test...
+OK
+
+Name:			anthony-test
+ID:			bbdb1ff6a36846e9b2dfb522a07005af
+State:			normal
+Created:		2017-10-09T21:43:56+0000
+Datacenter:		dal10
+Master URL:		https://qq.ww.ee.rr:qwer
+<b>Ingress subdomain:	anthony-test.us-south.containers.mybluemix.net
+Ingress secret:		anthony-test</b>
+Workers:		2
+Version:		1.7.4_1506* (1.8.6_1504 latest)
+</pre>
+
+* Add them in ingress.yaml
+
+<pre>
+...
+tls:
+    - hosts:
+      <b>- anthony-test.us-south.containers.mybluemix.net # Replace value with your own
+      secretName: anthony-test # Add this line and replace value with your own</b>
+  rules:
+  - host: <b>anthony-test.us-south.containers.mybluemix.net # Replace value with your own</b>
+...
+</pre>
+
+* Modify configmap.yaml
+
+Replace their values with your own
+
+<pre>
+FRONT_END_PLAYER_URL: <b>http://anthony-test.us-south.containers.mybluemix.net/players/v1/accounts</b>
+FRONT_END_SUCCESS_CALLBACK: <b>http://anthony-test.us-south.containers.mybluemix.net/#/login/callback</b>
+FRONT_END_FAIL_CALLBACK: <b>http://anthony-test.us-south.containers.mybluemix.net/#/game</b>
+FRONT_END_AUTH_URL: <b>http://anthony-test.us-south.containers.mybluemix.net/auth</b>
+</pre>
+
+## Create Kubernetes resources
+
+```
+kubectl apply -f kubernetes/ingress.yaml
+
+kubectl apply -f kubernetes/gameon-configmap.yaml 
+
+kubectl apply -f kubernetes/couchdb.yaml
+kubectl apply -f kubernetes/kafka.yaml
+
+kubectl apply -f kubernetes/auth.yaml
+kubectl apply -f kubernetes/mediator.yaml
+kubectl apply -f kubernetes/map.yaml
+kubectl apply -f kubernetes/player.yaml
+kubectl apply -f kubernetes/room.yaml
+kubectl apply -f kubernetes/webapp.yaml
+```
+
+## Delete Kubernetes Resources
+
+```
+kubectl delete -f kubernetes/ingress.yaml
+
+kubectl delete -f kubernetes/gameon-configmap.yaml 
+
+kubectl delete -f kubernetes/couchdb.yaml
+kubectl delete -f kubernetes/kafka.yaml
+
+kubectl delete -f kubernetes/auth.yaml
+kubectl delete -f kubernetes/mediator.yaml
+kubectl delete -f kubernetes/map.yaml
+kubectl delete -f kubernetes/player.yaml
+kubectl delete -f kubernetes/room.yaml
+kubectl delete -f kubernetes/webapp.yaml
+
+kubectl delete secret global-cert -n gameon-system
+```

--- a/kubernetes/auth.yaml
+++ b/kubernetes/auth.yaml
@@ -26,125 +26,19 @@ spec:
         app: gameon-auth
     spec:
       volumes:
-      - name: certificate 
-        configMap:
-          name: global-cert
-          items:
-          - key: cert.pem
-            path: cert.pem
+        - name: certificate
+          secret:
+            secretName: global-cert
       containers:
-      - image: mycluster.icp:8500/gameon-system/gameon-auth:latest
-        imagePullPolicy: Always
-        name: auth
-        ports:
-        - containerPort: 9080
+        - image: gameontext/gameon-auth:latest
+          imagePullPolicy: Always
           name: auth
-        volumeMounts:
-        - name: certificate 
-          mountPath: /etc/cert
-        env:
-          - name: GITHUB_APP_ID
-            valueFrom:
-              configMapKeyRef:
+          ports:
+            - containerPort: 9080
+              name: auth
+          volumeMounts:
+            - name: certificate 
+              mountPath: /etc/cert
+          envFrom:
+            - configMapRef:
                 name: global-config
-                key: GITHUB_APP_ID
-          - name: GITHUB_APP_SECRET
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: GITHUB_APP_SECRET
-          - name: TWITTER_CONSUMER_KEY
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: TWITTER_CONSUMER_KEY
-          - name: TWITTER_CONSUMER_SECRET
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: TWITTER_CONSUMER_SECRET
-          - name: MAP_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: MAP_SERVICE_URL
-          - name: PLAYER_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: PLAYER_SERVICE_URL
-          - name: COUCHDB_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: COUCHDB_SERVICE_URL
-          - name: KAFKA_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: KAFKA_SERVICE_URL
-          - name: FRONT_END_PLAYER_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: FRONT_END_PLAYER_URL
-          - name: FRONT_END_SUCCESS_CALLBACK
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: FRONT_END_SUCCESS_CALLBACK
-          - name: FRONT_END_FAIL_CALLBACK
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: FRONT_END_FAIL_CALLBACK
-          - name: FRONT_END_AUTH_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: FRONT_END_AUTH_URL
-          - name: GAMEON_MODE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: GAMEON_MODE
-          - name: TARGET_PLATFORM
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: TARGET_PLATFORM
-          - name: SYSTEM_ID
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: SYSTEM_ID
-          - name: LICENSE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LICENSE
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: ADMIN_PASSWORD
-          - name: WLP_SKIP_MAXPERMSIZE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_SKIP_MAXPERMSIZE
-          - name: WLP_OUTPUT_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_OUTPUT_DIR
-          - name: LOG_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LOG_DIR
-          - name: MAP_KEY
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: MAP_KEY

--- a/kubernetes/gameon-configmap.yaml
+++ b/kubernetes/gameon-configmap.yaml
@@ -8,8 +8,10 @@ data:
   GITHUB_APP_SECRET: ''
   TWITTER_CONSUMER_KEY: ''
   TWITTER_CONSUMER_SECRET: ''
-  MAP_SERVICE_URL: http://map.gameon-system.svc.cluster.local/map/map/v1/sites
-  PLAYER_SERVICE_URL: http://player.gameon-system.svc.cluster.local/players/players/v1/accounts
+  MAP_SERVICE_URL: http://map.gameon-system.svc.cluster.local:9080/map/v1/sites
+  MAP_HEALTH_SERVICE_URL: http://map.gameon-system.svc.cluster.local:9080/map/v1/health
+  PLAYER_SERVICE_URL: http://player.gameon-system.svc.cluster.local:9080/players/v1/accounts
+  RECROOM_SERVICE_URL: ws://room.gameon-system.svc.cluster.local:9080/rooms
   COUCHDB_SERVICE_URL: http://couchdb.gameon-system.svc.cluster.local:5984
   COUCHDB_HOST_AND_PORT: couchdb.gameon-system.svc.cluster.local:5984
   KAFKA_SERVICE_URL: kafka.gameon-system.svc.cluster.local:9092
@@ -21,7 +23,7 @@ data:
   TARGET_PLATFORM: local
   SYSTEM_ID: game-on.org
   LICENSE: accept
-  PROXY_DOCKER_HOST: '192.168.9.100'
+  PROXY_DOCKER_HOST: 'gameon.192.168.9.100.xip.io'
   ADMIN_PASSWORD: admin
   WLP_SKIP_MAXPERMSIZE: 'true'
   WLP_OUTPUT_DIR: /opt/ibm/wlp/usr/servers/

--- a/kubernetes/go-run.sh
+++ b/kubernetes/go-run.sh
@@ -47,6 +47,7 @@ platform_up() {
   kubectl create -f kubernetes/mediator.yaml
   kubectl create -f kubernetes/map.yaml
   kubectl create -f kubernetes/player.yaml
+  kubectl create -f kubernetes/room.yaml
   kubectl create -f kubernetes/webapp.yaml
 }
 
@@ -58,6 +59,7 @@ platform_down() {
   kubectl delete -f kubernetes/mediator.yaml
   kubectl delete -f kubernetes/map.yaml
   kubectl delete -f kubernetes/player.yaml
+  kubectl delete -f kubernetes/room.yaml
   kubectl delete -f kubernetes/webapp.yaml
 
   kubectl delete -f kubernetes/ingress.yaml
@@ -97,13 +99,13 @@ setup() {
   echo "..done"
  
   echo "Checking for cert config map"
-  kubectl get configmap --namespace=gameon-system global-cert > /dev/null 2>&1
+  kubectl get secret --namespace=gameon-system global-cert > /dev/null 2>&1
   if [ ! $? -eq 0 ]; then
     echo "..creating"
     openssl req -x509 -newkey rsa:4096 -keyout ./onlykey.pem -out ./onlycert.pem -days 365 -nodes
     cat ./onlycert.pem ./onlykey.pem > ./cert.pem
     rm ./onlycert.pem ./onlykey.pem
-    kubectl create configmap --namespace=gameon-system --from-file=./cert.pem global-cert
+    kubectl create secret generic --namespace=gameon-system --from-file=./cert.pem global-cert
   else
     echo "..ok"
   fi

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -27,6 +27,10 @@ spec:
         backend:
           serviceName: map 
           servicePort: 9080
+      - path: /rooms
+        backend:
+          serviceName: room
+          servicePort: 9080
       - path: /
         backend:
           serviceName: webapp

--- a/kubernetes/mediator.yaml
+++ b/kubernetes/mediator.yaml
@@ -26,80 +26,19 @@ spec:
         app: gameon-mediator
     spec:
       volumes:
-      - name: certificate
-        configMap:
-          name: global-cert
-          items:
-          - key: cert.pem
-            path: cert.pem
-      containers:
-      - image: mycluster.icp:8500/gameon-system/gameon-mediator:latest
-        imagePullPolicy: Always
-        name: mediator
-        ports:
-        - containerPort: 9080
-          name: mediator
-        volumeMounts:
         - name: certificate
-          mountPath: /etc/cert
-        env:
-          - name: PLAYER_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
+          secret:
+            secretName: global-cert
+      containers:
+        - image: gameontext/gameon-mediator:latest
+          imagePullPolicy: Always
+          name: mediator
+          ports:
+            - containerPort: 9080
+              name: mediator
+          volumeMounts:
+            - name: certificate
+              mountPath: /etc/cert
+          envFrom:
+            - configMapRef:
                 name: global-config
-                key: PLAYER_SERVICE_URL
-          - name: MAP_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: MAP_SERVICE_URL
-          - name: KAFKA_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: KAFKA_SERVICE_URL
-          - name: GAMEON_MODE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: GAMEON_MODE
-          - name: TARGET_PLATFORM
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: TARGET_PLATFORM
-          - name: SYSTEM_ID
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: SYSTEM_ID
-          - name: LICENSE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LICENSE
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: ADMIN_PASSWORD
-          - name: WLP_SKIP_MAXPERMSIZE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_SKIP_MAXPERMSIZE
-          - name: WLP_OUTPUT_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_OUTPUT_DIR
-          - name: LOG_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LOG_DIR
-          - name: MAP_KEY
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: MAP_KEY

--- a/kubernetes/player.yaml
+++ b/kubernetes/player.yaml
@@ -26,90 +26,19 @@ spec:
         app: gameon-player
     spec:
       volumes:
-      - name: certificate
-        configMap:
-          name: global-cert
-          items:
-          - key: cert.pem
-            path: cert.pem
-      containers:
-      - image: mycluster.icp:8500/gameon-system/gameon-player:latest
-        imagePullPolicy: Always
-        name: player
-        ports:
-        - containerPort: 9080
-          name: player
-        volumeMounts:
         - name: certificate
-          mountPath: /etc/cert
-        env:
-          - name: COUCHDB_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
+          secret:
+            secretName: global-cert
+      containers:
+        - image: gameontext/gameon-player:latest
+          imagePullPolicy: Always
+          name: player
+          ports:
+            - containerPort: 9080
+              name: player
+          volumeMounts:
+            - name: certificate
+              mountPath: /etc/cert
+          envFrom:
+            - configMapRef:
                 name: global-config
-                key: COUCHDB_SERVICE_URL
-          - name: COUCHDB_HOST_AND_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: COUCHDB_HOST_AND_PORT
-          - name: KAFKA_SERVICE_URL
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: KAFKA_SERVICE_URL
-          - name: GAMEON_MODE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: GAMEON_MODE
-          - name: TARGET_PLATFORM
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: TARGET_PLATFORM
-          - name: SYSTEM_ID
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: SYSTEM_ID
-          - name: LICENSE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LICENSE
-          - name: ADMIN_PASSWORD
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: ADMIN_PASSWORD
-          - name: WLP_SKIP_MAXPERMSIZE
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_SKIP_MAXPERMSIZE
-          - name: WLP_OUTPUT_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: WLP_OUTPUT_DIR
-          - name: LOG_DIR
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: LOG_DIR
-          - name: MAP_KEY
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: MAP_KEY
-          - name: COUCHDB_USER
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: COUCHDB_USER
-          - name: COUCHDB_PASSWORD
-            valueFrom:
-              configMapKeyRef:
-                name: global-config
-                key: COUCHDB_PASSWORD

--- a/kubernetes/room.yaml
+++ b/kubernetes/room.yaml
@@ -1,41 +1,41 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: map
+  name: room
   namespace: gameon-system
   labels:
-    app: gameon-map
+    app: gameon-room
 spec:
   type: ClusterIP
   ports:
     - port: 9080
   selector:
-    app: gameon-map
+    app: gameon-room
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: map
+  name: room
   namespace: gameon-system
   labels:
-    app: gameon-map
+    app: gameon-room
 spec:
   template:
     metadata:
       labels:
-        app: gameon-map
+        app: gameon-room
     spec:
       volumes:
         - name: certificate
           secret:
             secretName: global-cert
       containers:
-      - image: gameontext/gameon-map:latest
+      - image: gameontext/gameon-room:latest
         imagePullPolicy: Always
-        name: map
+        name: room
         ports:
           - containerPort: 9080
-            name: map
+            name: room
         volumeMounts:
           - name: certificate
             mountPath: /etc/cert

--- a/kubernetes/webapp.yaml
+++ b/kubernetes/webapp.yaml
@@ -26,8 +26,8 @@ spec:
         app: gameon-webapp
     spec:
       containers:
-      - image: mycluster.icp:8500/gameon-system/gameon-webapp:latest
-        imagePullPolicy: Always
-        name: webapp
-        ports:
-        - containerPort: 80
+        - image: gameontext/gameon-webapp:latest
+          imagePullPolicy: Always
+          name: webapp
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
This commit adds in instructions for deploying the gameon app in IBM Cloud Container service.
This commit also adds in the room service and room service environment variable in the configmap.
The generated certificate from openssl is now created as a secret instead of a configmap.
The yaml files using the certificate is now pointed to the new secret.
go-run.sh script should now create a secret from the generated certificate.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/119)
<!-- Reviewable:end -->
