### PR TITLE
Use the custom image to generate keystore

### DIFF
--- a/bin/gen-keystore.sh
+++ b/bin/gen-keystore.sh
@@ -144,5 +144,13 @@ keytool -importkeystore \
   -destkeystore keystore/truststore.jks \
   -srcstorepass changeit \
   -deststorepass truststore
+
+echo | openssl s_client -showcerts -servername *.googleapis.com -connect www.googleapis.com:443 </dev/null 2>&1 | sed -ne '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > keystore/googleca.pem
+ 
+keytool -import -v -trustcacerts -alias googleca -file keystore/googleca.pem -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks 
+
+curl https://secure.globalsign.net/cacert/Root-R2.crt > keystore/globalsign-r2.crt
+keytool -import -v -trustcacerts -alias globalsign-r2 -file keystore/globalsign-r2.crt -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks
+
 #clean up the public cert..
 rm -f keystore/public.crt

--- a/docker/docker-functions
+++ b/docker/docker-functions
@@ -120,6 +120,8 @@ ensure_keystore() {
     DOCKERPATHPREFIX=/
     sed -i 's/\r//' ${BIN_DIR}/gen-keystore.sh
   fi
+  
+  use_image=gameontext/docker-liberty-custom
 
   # If the keystore volume doesn't exist, then we should generate
   # the keystores we need for local signed JWTs to work
@@ -132,12 +134,12 @@ ensure_keystore() {
     wrap_docker run \
       -v keystore:/tmp/keystore \
       -v ${DOCKERPATHPREFIX}${BIN_DIR}/gen-keystore.sh:/tmp/gen-keystore.sh \
-      -w /tmp --rm ibmjava bash ./gen-keystore.sh ${GAMEON_HOST}
+      -w /tmp --rm ${use_image} bash ./gen-keystore.sh ${GAMEON_HOST}
     # Copy ltpa.keys
     wrap_docker run \
       -v keystore:/tmp/keystore \
       -v ${DOCKERPATHPREFIX}${IMG_DIR}/ltpa.keys:/tmp/ltpa.keys \
-      -w /tmp --rm ibmjava cp ltpa.keys keystore/ltpa.keys
+      -w /tmp --rm ${use_image} cp ltpa.keys keystore/ltpa.keys
   fi
 
   ## Ensure volume exists for node modules (avoid putting in filesystem because of OS differences)


### PR DESCRIPTION
Use the custom liberty build image (with curl) to create the keystore.
Also import google's keychain into that keystore for testing with Google APIs.

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/123)
<!-- Reviewable:end -->
