### PR TITLE
Change docker login to use the --passwd-stdin arg

### DIFF
--- a/build/dockerhub.sh
+++ b/build/dockerhub.sh
@@ -42,7 +42,7 @@ if [ "$TRAVIS_BRANCH" == "master" ]; then
   docker tag ${BUILD_TAG} ${LATEST_TAG}
 
   echo "Publishing image"
-  docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+  echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin
   docker push ${BUILD_TAG}
   docker push ${LATEST_TAG}
   docker logout


### PR DESCRIPTION
Per https://github.com/docker/cli/blob/e6e47d95b5e3c54592ef7cef6dedbec6687e66d8/cli/command/registry/login.go#L63 it seems that Travis is using what appears to be an interactive shell, so switching to using the `--passwd-stdin` flag per https://docs.docker.com/engine/reference/commandline/login/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/124)
<!-- Reviewable:end -->
