### PR TITLE
Move to couchdb 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 gameon.?*env
 docker-compose.override.yml
 kubernetes/kubectl/configmap.yaml
+kubernetes/kubectl/couchdb-pv.yaml
 kubernetes/kubectl/ingress.yaml
 kubernetes/istio/istio-gateway.yaml
 kubernetes/chart/gameon-system/values.yaml

--- a/bin/gen-certificate.sh
+++ b/bin/gen-certificate.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+targetDir=$1
+if [ -z "$targetDir" ]; then
+  echo "Usage: specify targetDir for generated certificate"
+  exit 1
+fi
+
+hostName=$2
+if [ -z "$hostName" ]; then
+  echo "Usage: specify Hostname or IP address for certificate as argument"
+  exit 1
+fi
+
+if [ -f ${targetDir}/.gameontext.onlycert.pem ]; then
+  subject=$(openssl x509 -in ${targetDir}/.gameontext.onlycert.pem -text -noout | grep Subject:)
+  cert_hostname=$(echo ${subject} | sed -e 's/ //g' -e 's/.*CN=\([^,/]*\).*/\1/')
+  if [ "$cert_hostname" != "$hostName" ]; then
+    echo "Existing certificate hostname (${cert_hostname}) does not match the requested hostname (${hostName}). Regenerating certificate"
+    rm ${targetDir}/.gameontext.cert.pem
+  fi
+fi
+
+mkdir -p ${targetDir}/.gameontext.openssl > /dev/null 2>&1
+
+# Create certificate (for signing JWTs)
+if [ ! -f ${targetDir}/.gameontext.cert.pem ]; then
+  echo " - Creating certificate for ${hostName} "
+
+  #Generate CA Key And Cert
+  echo " - Generating CA & Cert"
+  SUBJECT="/CN=gameontext.org/OU=GameOn Development CA/O=The Ficticious GameOn CA Company/L=Earth/ST=Happy/C=CA"
+  openssl genrsa -out ${targetDir}/.gameontext.openssl/server_rootCA.key 4096
+  openssl req -x509 -new -nodes -sha256 -days 3650 \
+    -key ${targetDir}/.gameontext.openssl/server_rootCA.key \
+    -out ${targetDir}/.gameontext.openssl/server_rootCA.pem \
+    -subj "${SUBJECT}"
+
+  #Create CSR config
+cat <<EOT > ${targetDir}/.gameontext.openssl/rootCSR.cnf
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[dn]
+C=CA
+ST=Happy
+L=Earth
+O=The Ficticious GameOn Company
+OU=GameOn Application
+CN = ${hostName}
+
+EOT
+
+cat <<EOT > ${targetDir}/.gameontext.openssl/v3.ext
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${hostName}
+
+EOT
+
+  echo " - Create Server Key & CSR"
+  #Create Server Key, with CSR
+  openssl req -new -sha256 -nodes \
+    -out ${targetDir}/.gameontext.openssl/server.csr -newkey rsa:4096 \
+    -keyout ${targetDir}/.gameontext.onlykey.pem -config <( cat ${targetDir}/.gameontext.openssl/rootCSR.cnf )
+
+  echo " - Sign CSR"
+  #Sign CSR with CA
+  openssl x509 -req \
+    -in ${targetDir}/.gameontext.openssl/server.csr \
+    -CA ${targetDir}/.gameontext.openssl/server_rootCA.pem \
+    -CAkey ${targetDir}/.gameontext.openssl/server_rootCA.key -CAcreateserial \
+    -out ${targetDir}/.gameontext.onlycert.pem -days 3650 -sha256 \
+    -extfile ${targetDir}/.gameontext.openssl/v3.ext
+
+  #Append Server Cert & Key into single file for haproxy.
+  cat ${targetDir}/.gameontext.onlycert.pem ${targetDir}/.gameontext.onlykey.pem > ${targetDir}/.gameontext.cert.pem
+fi

--- a/bin/gen-keystore.sh
+++ b/bin/gen-keystore.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 
+echo "** Populating keystore volume **"
+
 # Generate keystores in ./keystore for a given IP
-
-if (( $# != 1))
-then
-  echo "Usage: ./bin/gen-keystore.sh <IP>"
-  exit 1
-fi
-
-IP=$1
-
 if [ -z ${JAVA_HOME} ]
 then
   echo "JAVA_HOME is not set. Please set and re-run this script."
@@ -32,125 +25,53 @@ then
   exit 1
 fi
 
-echo "Generating key stores using ${IP}"
+if [ ! -f cert.pem ]; then
+  echo "Missing certificate"
+  exit 1
+fi
+if [ ! -f server.pem ]; then
+  echo "Missing server certificate"
+  exit 1
+fi
+if [ ! -f private.pem ]; then
+  echo "Missing key certificate"
+  exit 1
+fi
+if [ ! -f ltpa.keys ]; then
+  echo "Missing ltpa.keys"
+  exit 1
+fi
 
-#create a ca cert we'll import into all our trust stores..
-keytool -genkeypair \
-  -alias gameonca \
-  -keypass gameonca \
-  -storepass gameonca \
-  -keystore keystore/cakey.jks \
-  -keyalg RSA \
-  -keysize 2048 \
-  -dname "CN=GameOnLocalDevCA, OU=The Amazing GameOn Certificate Authority, O=The Ficticious GameOn Company, L=Earth, ST=Happy, C=CA" \
-  -ext KeyUsage="keyCertSign" \
-  -ext BasicConstraints:"critical=ca:true" \
-  -validity 9999
-#export the ca cert so we can add it to the trust stores
-keytool -exportcert \
-  -alias gameonca \
-  -keypass gameonca \
-  -storepass gameonca \
-  -keystore keystore/cakey.jks \
-  -file keystore/gameonca.crt \
-  -rfc
-#create the keypair we plan to use for our ssl/jwt signing
-keytool -genkeypair \
-  -alias gameonappkey \
-  -keypass testOnlyKeystore \
-  -storepass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -keyalg RSA \
-  -sigalg SHA1withRSA \
-  -dname "CN=${IP},OU=GameOn Application,O=The Ficticious GameOn Company,L=Earth,ST=Happy,C=CA" \
-  -validity 365
-#create the signing request for the app key
-keytool -certreq \
-  -alias gameonappkey \
-  -keypass testOnlyKeystore \
-  -storepass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -file keystore/appsignreq.csr
-#sign the cert with the ca
-keytool -gencert \
-  -alias gameonca \
-  -keypass gameonca \
-  -storepass gameonca \
-  -keystore keystore/cakey.jks \
-  -infile keystore/appsignreq.csr \
-  -outfile keystore/app.cer
-#import the ca cert
-keytool -importcert \
-  -alias gameonca \
-  -storepass testOnlyKeystore \
-  -keypass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -noprompt \
-  -file keystore/gameonca.crt
-#import the signed cert
-keytool -importcert \
-  -alias gameonappkey \
-  -storepass testOnlyKeystore \
-  -keypass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -noprompt \
-  -file keystore/app.cer
-#change the alias of the signed cert
-keytool -changealias \
-  -alias gameonappkey \
-  -destalias default \
-  -storepass testOnlyKeystore \
-  -keypass testOnlyKeystore \
-  -keystore keystore/key.jks
-#export the signed cert in pem format for proxy to use
-keytool -exportcert \
-  -alias default \
-  -storepass testOnlyKeystore \
-  -keypass testOnlyKeystore \
-  -keystore keystore/key.jks \
-  -file keystore/cert.pem \
-  -rfc
-#export the private key in pem format for proxy to use
-keytool -importkeystore \
-  -srckeystore keystore/key.jks \
-  -destkeystore keystore/key.p12 \
-  -srcstoretype jks \
-  -deststoretype pkcs12 \
-  -srcstorepass testOnlyKeystore \
-  -deststorepass testOnlyKeystore \
-  -srckeypass testOnlyKeystore \
-  -destkeypass testOnlyKeystore \
-  -srcalias default
-openssl pkcs12 \
-  -in keystore/key.p12 \
-  -out keystore/private.pem \
-  -nocerts \
-  -nodes \
-  -password pass:testOnlyKeystore
-#concat the public and private key for haproxy
-cat keystore/cert.pem keystore/private.pem > keystore/proxy.pem
-#add the cacert to the truststore
-keytool -importcert \
-  -alias gameonca \
-  -storepass truststore \
-  -keypass truststore \
-  -keystore keystore/truststore.jks \
-  -noprompt \
-  -trustcacerts \
-  -file keystore/gameonca.crt
-#add all jvm cacerts to the truststore.
-keytool -importkeystore \
-  -srckeystore $JAVA_HOME/lib/security/cacerts \
-  -destkeystore keystore/truststore.jks \
-  -srcstorepass changeit \
-  -deststorepass truststore
+cp *.pem keystore
+cp *.keys keystore
 
-echo | openssl s_client -showcerts -servername *.googleapis.com -connect www.googleapis.com:443 </dev/null 2>&1 | sed -ne '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > keystore/googleca.pem
+
+echo "Building keystore/truststore from cert.pem"
+
+echo "-converting pem to pkcs12"
+openssl pkcs12 -passin pass:keystore -passout pass:keystore -export -out cert.pkcs12 -in cert.pem
+
+echo "-importing pem to keystore/truststore.jks"
+keytool -import -v -trustcacerts -alias default -file cert.pem -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks
+
+echo "-creating dummy key.jks"
+keytool -genkey -storepass testOnlyKeystore -keypass wefwef -keyalg RSA -alias endeca -keystore keystore/key.jks -dname CN=rsssl,OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA
+
+echo "-emptying key.jks"
+keytool -delete -storepass testOnlyKeystore -alias endeca -keystore keystore/key.jks
+
+echo "-importing pkcs12 to key.jks"
+keytool -v -importkeystore -srcalias 1 -alias 1 -destalias default \
+  -noprompt -srcstorepass keystore -deststorepass testOnlyKeystore \
+  -srckeypass keystore -destkeypass testOnlyKeystore \
+  -srckeystore cert.pkcs12 -srcstoretype PKCS12 -destkeystore keystore/key.jks -deststoretype JKS
+
+# Adding google certs to truststore
+echo | openssl s_client -showcerts -servername *.googleapis.com \
+  -connect www.googleapis.com:443 </dev/null 2>&1 | sed -ne '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' > googleca.pem
  
-keytool -import -v -trustcacerts -alias googleca -file keystore/googleca.pem -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks 
+keytool -import -v -trustcacerts -alias googleca -file googleca.pem -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks 
 
-curl https://secure.globalsign.net/cacert/Root-R2.crt > keystore/globalsign-r2.crt
-keytool -import -v -trustcacerts -alias globalsign-r2 -file keystore/globalsign-r2.crt -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks
+curl https://secure.globalsign.net/cacert/Root-R2.crt > globalsign-r2.crt
+keytool -import -v -trustcacerts -alias globalsign-r2 -file globalsign-r2.crt -storepass truststore -keypass keystore -noprompt -keystore keystore/truststore.jks
 
-#clean up the public cert..
-rm -f keystore/public.crt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,7 +26,6 @@ services:
   auth:
     image: gameontext/gameon-auth:lastgood
     volumes:
-      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
       - 'keystore:/opt/ol/wlp/usr/servers/defaultServer/resources/security'
     depends_on:
       kafka:
@@ -39,7 +38,6 @@ services:
   map:
     image: gameontext/gameon-map:lastgood
     volumes:
-      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
       - 'keystore:/opt/ol/wlp/usr/servers/defaultServer/resources/security'
     depends_on:
       couchdb:
@@ -54,7 +52,6 @@ services:
   mediator:
     image: gameontext/gameon-mediator:lastgood
     volumes:
-      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
       - 'keystore:/opt/ol/wlp/usr/servers/defaultServer/resources/security'
     depends_on:
       kafka:
@@ -67,7 +64,6 @@ services:
   player:
     image: gameontext/gameon-player:lastgood
     volumes:
-      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
       - 'keystore:/opt/ol/wlp/usr/servers/defaultServer/resources/security'
     depends_on:
       couchdb:
@@ -82,7 +78,7 @@ services:
   proxy:
     image: gameontext/gameon-proxy:lastgood
     volumes:
-      - 'keystore:/keystore'
+      - 'keystore:/etc/cert'
     env_file: gameon.${DOCKER_MACHINE_NAME}env
     environment:
       - DNS_TCP_ADDR=127.0.0.11
@@ -97,7 +93,6 @@ services:
   room:
     image: gameontext/gameon-room:lastgood
     volumes:
-      - 'keystore:/opt/ibm/wlp/usr/servers/defaultServer/resources/security'
       - 'keystore:/opt/ol/wlp/usr/servers/defaultServer/resources/security'
     depends_on:
       kafka:
@@ -126,9 +121,12 @@ services:
     build:
       context: ../images/util
     image: gameon-util
-    command: tail -f /dev/null
+    depends_on:
+      couchdb:
+        condition: service_healthy
     volumes:
       - 'keystore:/keystore'
+      - 'couchdb-data:/opt/couchdb/data'
     env_file: gameon.${DOCKER_MACHINE_NAME}env
     container_name: util
     networks:
@@ -163,9 +161,10 @@ services:
 
 #### Local CouchDb Backend #########
   couchdb:
-    image: klaemo/couchdb:1.6.1
-    ports:
-      - "5984:5984"
+    image: couchdb:2.2
+    volumes:
+      - 'keystore:/etc/cert'
+      - 'couchdb-data:/opt/couchdb/data'
     container_name: couchdb
     healthcheck:
       test: curl http://localhost:5984/
@@ -179,4 +178,6 @@ networks:
 
 volumes:
   keystore:
+    external: true
+  couchdb-data:
     external: true

--- a/docker/docker-functions
+++ b/docker/docker-functions
@@ -106,6 +106,9 @@ build_webapp() {
 }
 
 ensure_keystore() {
+  # make sure certificates exist
+  ${BIN_DIR}/gen-certificate.sh "${GO_DIR}" "${GAMEON_HOST}"
+
   ## Creating Keystores
   # Docker volume operations need absolute paths
   DOCKERPATHPREFIX=
@@ -129,15 +132,14 @@ ensure_keystore() {
   then
     wrap_docker volume create --name keystore
     # Generate keystore
-    wrap_compose run -T\
+    wrap_compose run -T \
       -v keystore:/tmp/keystore \
       -v ${DOCKERPATHPREFIX}${BIN_DIR}/gen-keystore.sh:/tmp/gen-keystore.sh \
-      -w /tmp --rm util bash ./gen-keystore.sh ${GAMEON_HOST}
-    # Copy ltpa.keys
-    wrap_compose run -T\
-      -v keystore:/tmp/keystore \
+      -v ${GO_DIR}/.gameontext.cert.pem:/tmp/cert.pem \
+      -v ${GO_DIR}/.gameontext.onlycert.pem:/tmp/server.pem \
+      -v ${GO_DIR}/.gameontext.onlykey.pem:/tmp/private.pem \
       -v ${DOCKERPATHPREFIX}${IMG_DIR}/ltpa.keys:/tmp/ltpa.keys \
-      -w /tmp --rm util cp ltpa.keys keystore/ltpa.keys
+      -w /tmp --rm util bash ./gen-keystore.sh
   fi
 
   ## Ensure volume exists for node modules (avoid putting in filesystem because of OS differences)
@@ -149,7 +151,17 @@ ensure_keystore() {
   fi
 }
 
+ensure_datastore() {
+  wrap_docker volume inspect couchdb-data &> /dev/null
+  rc=$?
+  if [ $rc -ne 0 ]
+  then
+    wrap_docker volume create --name couchdb-data
+  fi
+}
+
 platform_up() {
+  ensure_datastore
   ensure_keystore
 
   FOUND=$(${DOCKER_CMD} ps --format="{{.Names}}")
@@ -186,7 +198,7 @@ reset_kafka() {
   echo "Stop kafka and dependent services"
   wrap_compose stop kafka ${PROJECTS}
   wrap_compose kill kafka ${PROJECTS}
-  wrap_composerm -f kafka ${PROJECTS}
+  wrap_compose rm -f kafka ${PROJECTS}
   echo "Resetting kafka takes some time ... "
   echo "Sleep 30"
   sleep 30
@@ -200,3 +212,15 @@ reset_kafka() {
   wrap_compose up -d  ${PROJECTS}
   wrap_compose logs --tail="5" -f  ${PROJECTS}
 }
+
+reset_db() {
+  read -p 'Clear data from couchdb? (y|N)' answer
+  if [ "$answer" == "y" ] || [ "$answer" == "Y" ]; then
+    echo "Stop couchdb"
+    wrap_compose stop couchdb util
+    wrap_compose rm -f couchdb util
+
+    wrap_docker volume rm -f couchdb-data
+  fi
+}
+

--- a/go-admin.sh
+++ b/go-admin.sh
@@ -73,10 +73,16 @@ case "$ACTION" in
     go_run setup
   ;;
   reset)
-    echo "Stopping the game and removing all Game On! configuration"
-    go_run down
-    go_run reset
-    rm -f .gameontext*
+    echo "======= "
+    echo "Stopping the game and removing all Game On! Docker Compose artifacts"
+    ./docker/go-run.sh down
+    ./docker/go-run.sh reset
+    ok "Docker Compose resources reset"
+    echo "======= "
+    echo "Stopping the game and removing all Game On! kubernetes artifacts"
+    ./kubernetes/go-run.sh down
+    ./kubernetes/go-run.sh reset
+    ok "Kubernetes resources reset"
   ;;
   up)
     if ! [ -f .gameontext ] || [ "$GO_DEPLOYMENT" != "$(< .gameontext)" ]; then

--- a/images/util/Dockerfile
+++ b/images/util/Dockerfile
@@ -12,3 +12,11 @@ ENV TGZ=kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 RUN wget -q "http://apache.mirrors.spacedump.net/kafka/${KAFKA_VERSION}/${TGZ}" -O /tmp/${TGZ} \
  && tar xfz /tmp/${TGZ} -C /opt \
  && rm /tmp/${TGZ}
+
+ADD https://raw.githubusercontent.com/gameontext/gameon/master/bin/init_couchdb.sh /init_couchdb.sh
+COPY ./startup.sh /startup.sh
+
+ENTRYPOINT []
+CMD [ "/startup.sh" ]
+
+HEALTHCHECK CMD test -f /initialized.txt

--- a/images/util/Dockerfile
+++ b/images/util/Dockerfile
@@ -1,4 +1,4 @@
-FROM gameontext/docker-liberty-custom:master-12
+FROM gameontext/docker-liberty-custom:master-14
 
 LABEL maintainer="Erin Schnabel <schnabel@us.ibm.com> (@ebullientworks)"
 

--- a/images/util/startup.sh
+++ b/images/util/startup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /init_couchdb.sh
+touch /initialized.txt
+exec tail -f /dev/null

--- a/kubernetes/.template.kubectl.ingress.yaml
+++ b/kubernetes/.template.kubectl.ingress.yaml
@@ -7,7 +7,7 @@ metadata:
 
 spec:
   backend:
-    serviceName: webapp.gameon-system.svc.cluster.local
+    serviceName: webapp
     servicePort: 8080
 # TLS block causes automatic redirection of http -> https
   tls:
@@ -20,25 +20,25 @@ spec:
       paths:
       - path: /auth
         backend:
-          serviceName: auth.gameon-system.svc.cluster.local
-          servicePort: 9080
-      - path: /players
-        backend:
-          serviceName: player.gameon-system.svc.cluster.local
-          servicePort: 9080
-      - path: /mediator
-        backend:
-          serviceName: mediator.gameon-system.svc.cluster.local
+          serviceName: auth
           servicePort: 9080
       - path: /map
         backend:
-          serviceName: map.gameon-system.svc.cluster.local
+          serviceName: map
+          servicePort: 9080
+      - path: /mediator
+        backend:
+          serviceName: mediator
+          servicePort: 9080
+      - path: /players
+        backend:
+          serviceName: player
           servicePort: 9080
       - path: /rooms
         backend:
-          serviceName: room.gameon-system.svc.cluster.local
+          serviceName: room
           servicePort: 9080
       - path: /swagger
         backend:
-          serviceName: swagger.gameon-system.svc.cluster.local
+          serviceName: swagger
           servicePort: 8080

--- a/kubernetes/.template.values.yaml
+++ b/kubernetes/.template.values.yaml
@@ -1,18 +1,19 @@
 global:
   frontDoor: GAME_FRONT_DOOR
+  frontDoorHost: GAMEON_INGRESS
   mode: development
   data:
 # Global: interservice communication
-    MAP_SERVICE_URL: http://map-service.gameon-system.svc.cluster.local:9080/map/v1/sites
-    MAP_HEALTH_SERVICE_URL: http://map-service.gameon-system.svc.cluster.local:9080/map/v1/health
-    PLAYER_SERVICE_URL: http://player-service.gameon-system.svc.cluster.local:9080/players/v1/accounts
+    MAP_SERVICE_URL: http://map.gameon-system.svc.cluster.local:9080/map/v1/sites
+    MAP_HEALTH_SERVICE_URL: http://map.gameon-system.svc.cluster.local:9080/map/v1/health
+    PLAYER_SERVICE_URL: http://player.gameon-system.svc.cluster.local:9080/players/v1/accounts
     RECROOM_SERVICE_URL: wss://GAME_FRONT_DOOR/rooms
 # Global: Common backing services
     COUCHDB_USER: mapUser
     COUCHDB_PASSWORD: myCouchDBSecret
-    COUCHDB_SERVICE_URL: http://couchdb-service.gameon-system.svc.cluster.local:5984
-    COUCHDB_HOST_AND_PORT: couchdb-service.gameon-system.svc.cluster.local:5984
-    KAFKA_SERVICE_URL: kafka-service.gameon-system.svc.cluster.local:9092
+    COUCHDB_SERVICE_URL: http://couchdb.gameon-system.svc.cluster.local:5984
+    COUCHDB_HOST_AND_PORT: couchdb.gameon-system.svc.cluster.local:5984
+    KAFKA_SERVICE_URL: kafka.gameon-system.svc.cluster.local:9092
     MESSAGEHUB_USER: ''
     MESSAGEHUB_PASSWORD: ''
 # Global configuration vars for running locally
@@ -42,7 +43,7 @@ ingress:
   tls:
   - hosts:
     - GAMEON_INGRESS
-    secretName: GAMEON_INGRESS_SECRET
+  secretName: GAMEON_INGRESS_SECRET
 #  Define default backend for the ingress
   backend:
     serviceName: webapp

--- a/kubernetes/chart/gameon-system/templates/_helpers.tpl
+++ b/kubernetes/chart/gameon-system/templates/_helpers.tpl
@@ -2,33 +2,12 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "gameon-system.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "gameon-system.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "gameon-system.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $.Chart.Name $.Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -38,6 +17,6 @@ Generate basic labels
     generator: helm
     date: {{ now | htmlDate }}
     chart: {{ template "gameon-system.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
 {{- end }}

--- a/kubernetes/chart/gameon-system/templates/coreservice.yaml
+++ b/kubernetes/chart/gameon-system/templates/coreservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .serviceName }}-service
+  name: {{ .serviceName }}
   namespace: gameon-system
   labels:
     app: {{ $.Chart.Name }}-{{ .serviceName }}

--- a/kubernetes/chart/gameon-system/templates/couchdb.yaml
+++ b/kubernetes/chart/gameon-system/templates/couchdb.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: couchdb-service
+  name: couchdb
   namespace: gameon-system
   labels:
     app: {{ .Chart.Name }}-couchdb
@@ -32,7 +32,7 @@ spec:
         app: {{ .Chart.Name}}-couchdb
     spec:
       containers:
-      - image: klaemo/couchdb:1.6.1
+      - image: couchdb:2.2
         name: couchdb
         ports:
         - containerPort: 5984

--- a/kubernetes/chart/gameon-system/templates/ingress.yaml
+++ b/kubernetes/chart/gameon-system/templates/ingress.yaml
@@ -21,19 +21,19 @@ spec:
 # TLS block causes automatic redirection of http -> https
   tls:
     - hosts:
-      - {{ .Values.global.frontDoor }}
+      - {{ .Values.global.frontDoorHost }}
 {{- with .Values.ingress.secretName }}
       secretName: {{ . }}
 {{- end }}
   rules:
-    - host: {{ .Values.global.frontDoor }}
+    - host: {{ .Values.global.frontDoorHost }}
       http:
         paths:
         {{- range .Values.coreServices }}
         {{- if eq (.skipIngress | default false) false }}
         - path: {{ .path }}
           backend:
-            serviceName: {{ .serviceName }}-service
+            serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}
         {{- end }}
         {{- end }}

--- a/kubernetes/chart/gameon-system/templates/kafka.yaml
+++ b/kubernetes/chart/gameon-system/templates/kafka.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kafka-service
+  name: kafka
   namespace: gameon-system
   labels:
     app: {{ .Chart.Name }}-kafka

--- a/kubernetes/go-run.sh
+++ b/kubernetes/go-run.sh
@@ -36,6 +36,7 @@ usage() {
 
 case "$ACTION" in
   reset)
+    platform_down
     reset_go
   ;;
   setup)
@@ -54,8 +55,8 @@ case "$ACTION" in
   ;;
   status)
     check_cluster_cfg
-    if wrap_kubectl -n gameon-system get po | grep -q mediator; then
-      wrap_kubectl -n gameon-system get all
+    if wrap_kubectl_go get po | grep -q mediator; then
+      wrap_kubectl_go get all
 
       echo "
 When ready, the game is available at https://${GAMEON_INGRESS}:${SECURE_INGRESS_PORT}/
@@ -70,7 +71,7 @@ When ready, the game is available at https://${GAMEON_INGRESS}:${SECURE_INGRESS_
   ;;
   wait)
     check_cluster_cfg
-    if wrap_kubectl -n gameon-system get po | grep -q mediator; then
+    if wrap_kubectl_go get po | grep -q mediator; then
       echo "Waiting for gameon-system pods to start"
       wait_until_ready -n gameon-system get pods
       echo ""

--- a/kubernetes/istio/istio-gatewayVirtualService.yaml
+++ b/kubernetes/istio/istio-gatewayVirtualService.yaml
@@ -14,56 +14,56 @@ spec:
         prefix: /auth
     route:
     - destination:
-        host: auth-service.gameon-system.svc.cluster.local
+        host: auth.gameon-system.svc.cluster.local
   - match:
     - uri:
         prefix: /map
     route:
     - destination:
-        host: map-service.gameon-system.svc.cluster.local
+        host: map.gameon-system.svc.cluster.local
   - websocketUpgrade: true
     match:
     - uri:
         prefix: /mediator/ws
     route:
     - destination:
-        host: mediator-service.gameon-system.svc.cluster.local
+        host: mediator.gameon-system.svc.cluster.local
   - match:
     - uri:
         prefix: /mediator
     route:
     - destination:
-        host: mediator-service.gameon-system.svc.cluster.local
+        host: mediator.gameon-system.svc.cluster.local
   - match:
     - uri:
         prefix: /players
     route:
     - destination:
-        host: player-service.gameon-system.svc.cluster.local
+        host: player.gameon-system.svc.cluster.local
   - websocketUpgrade: true
     match:
     - uri:
         prefix: /rooms/ws
     route:
     - destination:
-        host: room-service.gameon-system.svc.cluster.local
+        host: room.gameon-system.svc.cluster.local
   - match:
     - uri:
         prefix: /rooms
     route:
     - destination:
-        host: room-service.gameon-system.svc.cluster.local
+        host: room.gameon-system.svc.cluster.local
   - match:
     - uri:
         exact: /swagger
-    redirect: 
+    redirect:
         uri: /swagger/
   - match:
     - uri:
         prefix: /swagger/
     route:
     - destination:
-        host: swagger-service.gameon-system.svc.cluster.local
+        host: swagger.gameon-system.svc.cluster.local
   - route:
     - destination:
-        host: webapp-service.gameon-system.svc.cluster.local
+        host: webapp.gameon-system.svc.cluster.local

--- a/kubernetes/k8s-functions
+++ b/kubernetes/k8s-functions
@@ -2,6 +2,12 @@ BIN_DIR=$( cd "$SCRIPTDIR/../bin" && pwd )
 GO_DIR=$( cd "$SCRIPTDIR/.." && pwd )
 source $BIN_DIR/go-common
 
+if sed --version >/dev/null 2>&1; then
+  GNU_SED=1
+else
+  unset GNU_SED
+fi
+
 GO_DEPLOYMENT=kubernetes
 COREPROJECTS="auth map mediator player proxy room swagger webapp"
 
@@ -9,6 +15,12 @@ wrap_kubectl() {
   echo "
 > kubectl $@"
   kubectl $@
+}
+
+wrap_kubectl_go() {
+  echo "
+> kubectl -n gameon-system $@"
+  kubectl -n gameon-system $@
 }
 
 wrap_exec_kubectl() {
@@ -45,7 +57,7 @@ wait_until_ready() {
 
 sed_file() {
   if [ -f "${GO_DIR}/$2" ]; then
-    if [ "${GNU_SED}" ]; then
+    if [ "${GNU_SED}" == "1" ]; then
       sed -i -e "$1" "${GO_DIR}/$2"
     else
       sed -i '' -e "$1" "${GO_DIR}/$2"
@@ -81,7 +93,7 @@ ${kubectx}"
     fi
   else
     fixme "Please ensure your kubernetes cluster has been prepared properly
-    go-run prep"
+    go-run setup"
     exit 1
   fi
 }
@@ -189,8 +201,8 @@ init_namespace() {
       fixme "unable to  create gameon-system namespace"
       exit 1
     fi
-    wrap_helm version --client| grep "+icp" > /dev/null 2>&1
-    if [ $? ]; then
+
+    if [ "${GAMEON_USE_HELM}" ] && wrap_helm version --client| grep -q "+icp"; then
       echo "Applying kube pod security policy for go namespace"
       wrap_kubectl apply -f kubernetes/icp-psp.yaml
     fi
@@ -210,13 +222,17 @@ init_namespace() {
     else
       wrap_kubectl label namespace gameon-system istio-injection=enabled
     fi
+    # disable kubernetes ingress
     sed_file '/^ *ingress:/,/^ *[^:]*:/ s/enabled: .*/enabled: false/' kubernetes/chart/gameon-system/values.yaml
     cp -n kubernetes/.template.istio.istio-gateway.yaml kubernetes/istio/istio-gateway.yaml
-  elif [ "${GAMEON_USE_HELM}" ]; then
-    install_tiller
+  else
+    if [ "${GAMEON_USE_HELM}" ]; then
+      install_tiller
+    fi
     if [ -z ${INGRESS_PORT+x} ]; then
       find_k8s_ingress
     fi
+    # Enable kubernetes ingress
     cp -n kubernetes/.template.kubectl.ingress.yaml kubernetes/kubectl/ingress.yaml
     sed_file '/^ *ingress:/,/^ *[^:]*:/ s/enabled: .*/enabled: true/' kubernetes/chart/gameon-system/values.yaml
   fi
@@ -231,6 +247,7 @@ init_namespace() {
   local GAME_FRONT_DOOR=${GAMEON_INGRESS}:${SECURE_INGRESS_PORT}
 
   sed_file "s/frontDoor: .*$/frontDoor: ${GAME_FRONT_DOOR}/" kubernetes/chart/gameon-system/values.yaml
+  sed_file "s/frontDoorHost: .*$/frontDoorHost: ${GAMEON_INGRESS}/" kubernetes/chart/gameon-system/values.yaml
 
   sed_file "s/RECROOM_SERVICE_URL: .*$/RECROOM_SERVICE_URL: wss:\/\/${GAME_FRONT_DOOR}\/rooms/" kubernetes/kubectl/configmap.yaml
   sed_file "s/RECROOM_SERVICE_URL: .*$/RECROOM_SERVICE_URL: wss:\/\/${GAME_FRONT_DOOR}\/rooms/" kubernetes/chart/gameon-system/values.yaml
@@ -240,9 +257,8 @@ init_namespace() {
   sed_file "s/FRONT_END_AUTH_URL:.*$/FRONT_END_AUTH_URL: https:\/\/${GAME_FRONT_DOOR}\/auth/" kubernetes/kubectl/configmap.yaml
 
   # Gameon Ingress (host)
-
   ## Holy sed magic.
-  #  Replace hosts with GAMEON_INGRESS. Match hosts:, and then skip that line (/n), and replace the next one.
+  ## Replace hosts with ${GAMEON_INGRESS}. Match hosts:, and then skip that line (/n), and replace the next one.
   sed_file "/^ *- hosts:/,/^ *[^:]*:/ {
      /^ *- hosts:/n
      s/- .*$/- ${GAMEON_INGRESS}/
@@ -370,7 +386,7 @@ See: https://istio.io/docs/setup/kubernetes/helm-install/
 
 Run prep again once Istio has been installed in your cluster.
 
-    go-run prep"
+    go-run setup"
     exit 1
   fi
 }
@@ -397,7 +413,7 @@ test_local_kubernetes() {
   fi
 
   if [ ! -z ${GAMEON_LOCAL+x} ]; then
-    GAMEON_INGRESS_SECRET=
+    GAMEON_INGRESS_SECRET=front-door-certs
     GAMEON_INTERNAL_IPRANGE="10.0.0.1/24"
   fi
 }
@@ -478,80 +494,51 @@ define_ingress() {
 }
 
 create_certificate() {
+  local mtime=
+  if [ -f .gameontext.cert.pem ]; then
+    mtime=$(date -r .gameontext.cert.pem)
+  fi
 
-  # Create certificate (for signing JWTs)
-  if [ ! -f .gameontext.cert.pem ]; then
-    
-    mkdir ${GO_DIR}/.gameontext.openssl > /dev/null 2>&1
+  ${BIN_DIR}/gen-certificate.sh "${GO_DIR}" "${GAMEON_INGRESS}"
 
-    echo " - Creating certificate for ${GAMEON_INGRESS} "
-
-    #Generate CA Key And Cert
-    echo " - Generating CA & Cert"
-    SUBJECT="/CN=gameontext.org/OU=GameOn Development CA/O=The Ficticious GameOn CA Company/L=Earth/ST=Happy/C=CA"
-    openssl genrsa -out ${GO_DIR}/.gameontext.openssl/server_rootCA.key 4096
-    openssl req -x509 -new -nodes -key ${GO_DIR}/.gameontext.openssl/server_rootCA.key -sha256 -days 3650 -out ${GO_DIR}/.gameontext.openssl/server_rootCA.pem -subj "${SUBJECT}"
-
-    #Create CSR config
-cat <<EOT > ${GO_DIR}/.gameontext.openssl/rootCSR.cnf 
-[req]
-default_bits = 4096
-prompt = no
-default_md = sha256
-distinguished_name = dn
-
-[dn]
-C=CA
-ST=Happy
-L=Earth
-O=The Ficticious GameOn Company
-OU=GameOn Application
-CN = ${GAMEON_INGRESS}
-
-EOT
-
-cat <<EOT > ${GO_DIR}/.gameontext.openssl/v3.ext
-authorityKeyIdentifier=keyid,issuer
-basicConstraints=CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-subjectAltName = @alt_names
-
-[alt_names]
-DNS.1 = ${GAMEON_INGRESS}
-
-EOT
-
-    echo " - Create Server Key & CSR"
-    #Create Server Key, with CSR 
-    openssl req -new -sha256 -nodes -out ${GO_DIR}/.gameontext.openssl/server.csr -newkey rsa:4096 -keyout .gameontext.onlykey.pem -config <( cat ${GO_DIR}/.gameontext.openssl/rootCSR.cnf )
-    
-    echo " - Sign CSR"
-    #Sign CSR with CA 
-    openssl x509 -req -in ${GO_DIR}/.gameontext.openssl/server.csr -CA ${GO_DIR}/.gameontext.openssl/server_rootCA.pem -CAkey ${GO_DIR}/.gameontext.openssl/server_rootCA.key -CAcreateserial -out .gameontext.onlycert.pem -days 3650 -sha256 -extfile ${GO_DIR}/.gameontext.openssl/v3.ext
-
-    #Append Server Cert & Key into single file for GameOn Use.
-    cat .gameontext.onlycert.pem .gameontext.onlykey.pem > .gameontext.cert.pem
-
+  local mtime2=$(date -r .gameontext.cert.pem)
+  if [ "$mtime" != "$mtime2" ]; then
     ok "Created a new certificate (.gameontext.cert.pem)"
     check_global_cert force
   fi
 }
 
 check_global_cert() {
-  wrap_kubectl -n gameon-system get secret global-cert 2>/dev/null
+  wrap_kubectl_go get secret global-cert 2>/dev/null
   local exists=$?
 
   if [ $# -gt 0 ] && [ $exists -eq 0 ]; then
-    wrap_kubectl -n gameon-system delete secret global-cert
+    wrap_kubectl_go delete secret global-cert
     ok "Deleted old global-cert secret in gameon-system namespace"
     exists=1
   fi
 
   if [ $exists -eq 1 ]; then
-    wrap_kubectl -n gameon-system create secret generic global-cert --from-file=cert.pem=.gameontext.cert.pem
+    wrap_kubectl_go create secret generic global-cert --from-file=cert.pem=.gameontext.cert.pem
     ok "Created global-cert secret in gameon-system namespace"
   else
     ok "Found global-cert secret in gameon-system namespace"
+  fi
+
+  wrap_kubectl_go get secret front-door-certs 2>/dev/null
+  local exists=$?
+
+  if [ $# -gt 0 ] && [ $exists -eq 0 ]; then
+    wrap_kubectl_go delete secret front-door-certs
+    ok "Deleted old front-door-certs secret in gameon-system namespace"
+    exists=1
+  fi
+
+  if [ $exists -eq 1 ]; then
+    wrap_kubectl_go create secret tls front-door-certs --cert=.gameontext.onlycert.pem --key=.gameontext.onlykey.pem
+    ok "Created front-door-certs secret in gameon-system namespace"
+  else
+    ok "Found front-door-certs secret in gameon-system namespace"
   fi
 
   if [ "${GAMEON_USE_ISTIO}" ]; then
@@ -743,11 +730,6 @@ check_versions() {
 set_env() {
   source .gameontext.kubernetes
   set_istio_path
-  if sed --version >/dev/null 2>&1; then
-    GNU_SED=1
-  else
-    unset GNU_SED
-  fi
 }
 
 get_istio_path() {
@@ -756,7 +738,7 @@ get_istio_path() {
 }
 
 set_istio_path() {
-  if [ ! -z ${ISTIO_INSTALL+x} ]; then
+  if [ -n "${ISTIO_INSTALL}" ]; then
     if ! grep -q ${ISTIO_INSTALL} ${PATH} 2>/dev/null; then
       PATH=${ISTIO_INSTALL}/bin:${PATH}
     fi

--- a/kubernetes/kubectl/auth.yaml
+++ b/kubernetes/kubectl/auth.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: auth
+  name: auth-deploy
   namespace: gameon-system
   labels:
     app: gameon-auth
@@ -31,11 +31,12 @@ spec:
         secret:
           secretName: global-cert
       containers:
-      - image: gameontext/gameon-auth:lastgood
-        name: auth
+      - name: auth
+        image: gameontext/gameon-auth:lastgood
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 9080
-          name: auth
+        - name: auth
+          containerPort: 9080
         readinessProbe:
           httpGet:
             path: /auth/health

--- a/kubernetes/kubectl/couchdb.yaml
+++ b/kubernetes/kubectl/couchdb.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: gameon-couchdb
 spec:
+  type: ClusterIP
   ports:
   - port: 5984
     protocol: TCP
@@ -16,11 +17,14 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: couchdb
+  name: couchdb-deploy
   namespace: gameon-system
   labels:
     app: gameon-couchdb
 spec:
+  selector:
+    matchLabels:
+      app: gameon-couchdb
   strategy:
     type: Recreate
   template:
@@ -29,8 +33,12 @@ spec:
         app: gameon-couchdb
     spec:
       containers:
-      - image: klaemo/couchdb:1.6.1
-        name: couchdb
+      - name: couchdb
+        image: couchdb:2.2
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 5984
-          name: couchdb
+        - name: couchdb
+          containerPort: 5984
+        - name: epmd
+          containerPort: 4369
+        - containerPort: 9100

--- a/kubernetes/kubectl/kafka.yaml
+++ b/kubernetes/kubectl/kafka.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: gameon
 spec:
+  type: ClusterIP
   ports:
   - port: 9092
     protocol: TCP
@@ -16,7 +17,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: kafka
+  name: kafka-deploy
   namespace: gameon-system
   labels:
     app: gameon-kafka
@@ -29,9 +30,10 @@ spec:
         app: gameon-kafka
     spec:
       containers:
-      - image: gameontext/go-reactive-sandbox:latest
+      - name: kafka
+        image: gameontext/go-reactive-sandbox:latest
         imagePullPolicy: IfNotPresent
-        name: kafka
         ports:
-        - containerPort: 9092
-          name: kafka
+        - name: kafka
+          containerPort: 9092
+

--- a/kubernetes/kubectl/map.yaml
+++ b/kubernetes/kubectl/map.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: map
+  name: map-deploy
   namespace: gameon-system
   labels:
     app: gameon-map
@@ -31,11 +31,12 @@ spec:
         secret:
           secretName: global-cert
       containers:
-      - image: gameontext/gameon-map:lastgood
-        name: map
+      - name: map
+        image: gameontext/gameon-map:lastgood
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 9080
-          name: map
+        - name: map
+          containerPort: 9080
         readinessProbe:
           httpGet:
             path: /map/v1/health

--- a/kubernetes/kubectl/mediator.yaml
+++ b/kubernetes/kubectl/mediator.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: mediator
+  name: mediator-deploy
   namespace: gameon-system
   labels:
     app: gameon-mediator
@@ -31,11 +31,12 @@ spec:
         secret:
           secretName: global-cert
       containers:
-      - image: gameontext/gameon-mediator:lastgood
-        name: mediator
+      - name: mediator
+        image: gameontext/gameon-mediator:lastgood
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 9080
-          name: mediator
+        - name: mediator
+          containerPort: 9080
         readinessProbe:
           httpGet:
             path: /mediator/

--- a/kubernetes/kubectl/player.yaml
+++ b/kubernetes/kubectl/player.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: player
+  name: player-deploy
   namespace: gameon-system
   labels:
     app: gameon-player
@@ -31,11 +31,12 @@ spec:
         secret:
           secretName: global-cert
       containers:
-      - image: gameontext/gameon-player:lastgood
-        name: player
+      - name: player
+        image: gameontext/gameon-player:lastgood
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 9080
-          name: player
+        - name: player
+          containerPort: 9080
         readinessProbe:
           httpGet:
             path: /players/v1/health

--- a/kubernetes/kubectl/room.yaml
+++ b/kubernetes/kubectl/room.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: room
+  name: room-deploy
   namespace: gameon-system
   labels:
     app: gameon-room
@@ -31,11 +31,12 @@ spec:
         secret:
           secretName: global-cert
       containers:
-      - image: gameontext/gameon-room:lastgood
-        name: room
+      - name: room
+        image: gameontext/gameon-room:lastgood
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 9080
-          name: room
+        - name: room
+          containerPort: 9080
         readinessProbe:
           httpGet:
             path: /

--- a/kubernetes/kubectl/swagger.yaml
+++ b/kubernetes/kubectl/swagger.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: swagger
+  name: swagger-deploy
   namespace: gameon-system
   labels:
     app: gameon-swagger
@@ -28,6 +28,7 @@ spec:
     spec:
       containers:
       - image: gameontext/gameon-swagger:lastgood
+        imagePullPolicy: IfNotPresent
         name: swagger
         ports:
         - containerPort: 8080

--- a/kubernetes/kubectl/webapp.yaml
+++ b/kubernetes/kubectl/webapp.yaml
@@ -16,7 +16,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: webapp
+  name: webapp-deploy
   namespace: gameon-system
   labels:
     app: gameon-webapp
@@ -28,6 +28,7 @@ spec:
     spec:
       containers:
       - image: gameontext/gameon-webapp:lastgood
+        imagePullPolicy: IfNotPresent
         name: webapp
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Couchdb 2.2 brought some changes with how things are initialized and torn down, which caused some ripples. Some of this is incidental: making the certificate management path the same for kubernetes and docker, for example.

An external volume is used for couchdb data in the docker path. We're in a holding pattern for the kubernetes path, as the wiser choice is to use OOTB artifacts for couchdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/140)
<!-- Reviewable:end -->
