### PR TITLE
hostname IP SAN

### DIFF
--- a/bin/gen-certificate.sh
+++ b/bin/gen-certificate.sh
@@ -62,6 +62,7 @@ subjectAltName = @alt_names
 
 [alt_names]
 DNS.1 = ${hostName}
+IP.1 = ${hostName}
 
 EOT
 


### PR DESCRIPTION
Seems Go needs the SAN to be of type IP rather than DNS, so add both. 
Note if the hostName is actually a hostName, this might not make sense.. don't merge if you think this is bonkers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/142)
<!-- Reviewable:end -->
