### PR TITLE
K8S rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ docker-compose.override.yml
 kubernetes/kubectl/configmap.yaml
 kubernetes/kubectl/couchdb-pv.yaml
 kubernetes/kubectl/ingress.yaml
+kubernetes/kubectl/mediator.yaml
 kubernetes/istio/istio-gateway.yaml
 kubernetes/chart/gameon-system/values.yaml
 slackin

--- a/kubernetes/.template.kubectl.configmap.yaml
+++ b/kubernetes/.template.kubectl.configmap.yaml
@@ -10,30 +10,13 @@ data:
   PLAYER_SERVICE_URL: http://player.gameon-system.svc.cluster.local:9080/players/v1/accounts
   RECROOM_SERVICE_URL: wss://GAME_FRONT_DOOR/rooms
 # Global: Common backing services
-  COUCHDB_USER: mapUser
-  COUCHDB_PASSWORD: myCouchDBSecret
   COUCHDB_SERVICE_URL: http://couchdb.gameon-system.svc.cluster.local:5984
   COUCHDB_HOST_AND_PORT: couchdb.gameon-system.svc.cluster.local:5984
   KAFKA_SERVICE_URL: kafka.gameon-system.svc.cluster.local:9092
-  MESSAGEHUB_USER: ''
-  MESSAGEHUB_PASSWORD: ''
 # Global configuration vars for running locally
   GAMEON_MODE: development
   TARGET_PLATFORM: local
-  SYSTEM_ID: game-on.org
-  ADMIN_PASSWORD: admin
-  MAP_KEY: fish
-  SWEEP_ID: sweep
-  SWEEP_SECRET: sweepSecret
 # Auth service environment variables
-  FACEBOOK_APP_ID: ''
-  FACEBOOK_APP_SECRET: ''
-  GITHUB_APP_ID: ''
-  GITHUB_APP_SECRET: ''
-  GOOGLE_APP_ID: ''
-  GOOGLE_APP_SECRET: ''
-  TWITTER_CONSUMER_KEY: ''
-  TWITTER_CONSUMER_SECRET: ''
   FRONT_END_SUCCESS_CALLBACK: https://GAME_FRONT_DOOR/#/login/callback
   FRONT_END_FAIL_CALLBACK: https://GAME_FRONT_DOOR/#/login?login_failed
   FRONT_END_AUTH_URL: https://GAME_FRONT_DOOR/auth

--- a/kubernetes/.template.kubectl.mediator.yaml
+++ b/kubernetes/.template.kubectl.mediator.yaml
@@ -25,6 +25,8 @@ spec:
     metadata:
       labels:
         app: gameon-mediator
+      annotations:
+        traffic.sidecar.istio.io/includeOutboundIPRanges: 10.0.0.1/24
     spec:
       volumes:
       - name: certificate
@@ -48,3 +50,5 @@ spec:
         envFrom:
         - configMapRef:
             name: global-config
+        - secretRef:
+            name: global-secret

--- a/kubernetes/.template.kubectl.secret.yaml
+++ b/kubernetes/.template.kubectl.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: global-secret
+  namespace: gameon-system
+stringData:
+  COUCHDB_USER: mapUser
+  COUCHDB_PASSWORD: myCouchDBSecret
+  MESSAGEHUB_USER: ''
+  MESSAGEHUB_PASSWORD: ''
+  SYSTEM_ID: game-on.org
+  ADMIN_PASSWORD: admin
+  MAP_KEY: fish
+  SWEEP_ID: sweep
+  SWEEP_SECRET: sweepSecret
+# Auth service environment variables
+  FACEBOOK_APP_ID: ''
+  FACEBOOK_APP_SECRET: ''
+  GITHUB_APP_ID: ''
+  GITHUB_APP_SECRET: ''
+  GOOGLE_APP_ID: ''
+  GOOGLE_APP_SECRET: ''
+  TWITTER_CONSUMER_KEY: ''
+  TWITTER_CONSUMER_SECRET: ''

--- a/kubernetes/.template.values.yaml
+++ b/kubernetes/.template.values.yaml
@@ -2,6 +2,7 @@ global:
   frontDoor: GAME_FRONT_DOOR
   frontDoorHost: GAMEON_INGRESS
   mode: development
+  includeIPRanges: GAMEON_INTERNAL_IPRANGE
   data:
 # Global: interservice communication
     MAP_SERVICE_URL: http://map.gameon-system.svc.cluster.local:9080/map/v1/sites
@@ -9,15 +10,18 @@ global:
     PLAYER_SERVICE_URL: http://player.gameon-system.svc.cluster.local:9080/players/v1/accounts
     RECROOM_SERVICE_URL: wss://GAME_FRONT_DOOR/rooms
 # Global: Common backing services
-    COUCHDB_USER: mapUser
-    COUCHDB_PASSWORD: myCouchDBSecret
     COUCHDB_SERVICE_URL: http://couchdb.gameon-system.svc.cluster.local:5984
     COUCHDB_HOST_AND_PORT: couchdb.gameon-system.svc.cluster.local:5984
     KAFKA_SERVICE_URL: kafka.gameon-system.svc.cluster.local:9092
-    MESSAGEHUB_USER: ''
-    MESSAGEHUB_PASSWORD: ''
 # Global configuration vars for running locally
     TARGET_PLATFORM: local
+
+globalsecrets:
+  data:
+    COUCHDB_USER: mapUser
+    COUCHDB_PASSWORD: myCouchDBSecret
+    MESSAGEHUB_USER: ''
+    MESSAGEHUB_PASSWORD: ''
     SYSTEM_ID: game-on.org
     ADMIN_PASSWORD: admin
     MAP_KEY: fish

--- a/kubernetes/chart/gameon-system/templates/configmap/auth-config.yaml
+++ b/kubernetes/chart/gameon-system/templates/configmap/auth-config.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ .Chart.Name }}-auth-config
   namespace: gameon-system
   labels:
     {{- include "gameon-system.labels" . }}
-data:
+stringData:
 # Auth service environment variables
   {{- range  $key, $val := .Values.auth.data }}
   {{ $key }}: {{ $val | quote }}

--- a/kubernetes/chart/gameon-system/templates/configmap/global-secrets.yaml
+++ b/kubernetes/chart/gameon-system/templates/configmap/global-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Chart.Name }}-global-secret
+  namespace: gameon-system
+  labels:
+    {{- include "gameon-system.labels" . }}
+stringData:
+  {{- range  $key, $val := .Values.globalsecrets.data }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/kubernetes/chart/gameon-system/templates/coredeployment.yaml
+++ b/kubernetes/chart/gameon-system/templates/coredeployment.yaml
@@ -1,3 +1,4 @@
+{{- $iprange := .Values.global.includeIPRanges }}
 {{- range .Values.coreServices }}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -10,6 +11,10 @@ metadata:
 spec:
   template:
     metadata:
+{{- if eq .serviceName "mediator" }}
+      annotations:
+        traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $iprange }}
+{{- end }}
       labels:
         app: {{ $.Chart.Name }}-{{ .serviceName }}
     spec:
@@ -37,6 +42,8 @@ spec:
             - name: certificate
               mountPath: /etc/cert
           envFrom:
+            - secretRef:
+                name: gameon-system-global-secret
             - configMapRef:
                 name: gameon-system-global-config
           {{- if .configMapRef }}

--- a/kubernetes/k8s-functions
+++ b/kubernetes/k8s-functions
@@ -103,6 +103,7 @@ reset_go() {
   rm -f .gameontext.*.pem
   rm -f kubernetes/kubectl/ingress.yaml
   rm -f kubernetes/kubectl/configmap.yaml
+  rm -f kubernetes/kubectl/secret.yaml
   rm -f kubernetes/chart/gameon-system/values.yaml
   echo '' > .gameontext.kubernetes
   unset GAMEON_KUBECTL_CONTEXT
@@ -137,6 +138,7 @@ prepare() {
 
   # create new files from templates if they don't already exist
   cp -n kubernetes/.template.kubectl.configmap.yaml kubernetes/kubectl/configmap.yaml
+  cp -n kubernetes/.template.kubectl.secret.yaml kubernetes/kubectl/secret.yaml
   cp -n kubernetes/.template.values.yaml kubernetes/chart/gameon-system/values.yaml
 
   init_namespace
@@ -238,6 +240,13 @@ init_namespace() {
   fi
 
   create_certificate
+
+  # Add internal ip range to kubectl yaml (using # not / to avoid having to escape /24 in range)
+  cp -n kubernetes/.template.kubectl.mediator.yaml kubernetes/kubectl/mediator.yaml
+  sed_file "s#includeOutboundIPRanges: .*#includeOutboundIPRanges: ${GAMEON_INTERNAL_IPRANGE}#" kubernetes/kubectl/mediator.yaml
+
+  # Add internal ip range to chart (using # not / to avoid having to escape /24 in range)
+  sed_file "s#includeIPRanges: .*#includeIPRanges: ${GAMEON_INTERNAL_IPRANGE}#" kubernetes/chart/gameon-system/values.yaml
 
   # Ingress Secret
   sed_file "s/secretName: .*$/secretName: ${GAMEON_INGRESS_SECRET}/" kubernetes/chart/gameon-system/values.yaml

--- a/kubernetes/kubectl/auth.yaml
+++ b/kubernetes/kubectl/auth.yaml
@@ -48,3 +48,5 @@ spec:
         envFrom:
         - configMapRef:
             name: global-config
+        - secretRef:
+            name: global-secret

--- a/kubernetes/kubectl/map.yaml
+++ b/kubernetes/kubectl/map.yaml
@@ -48,3 +48,5 @@ spec:
         envFrom:
         - configMapRef:
             name: global-config
+        - secretRef:
+            name: global-secret

--- a/kubernetes/kubectl/player.yaml
+++ b/kubernetes/kubectl/player.yaml
@@ -48,3 +48,5 @@ spec:
         envFrom:
         - configMapRef:
             name: global-config
+        - secretRef:
+            name: global-secret

--- a/kubernetes/kubectl/room.yaml
+++ b/kubernetes/kubectl/room.yaml
@@ -48,3 +48,5 @@ spec:
         envFrom:
         - configMapRef:
             name: global-config
+        - secretRef:
+            name: global-secret


### PR DESCRIPTION
First pass splitting secrets away from config map.
 - Same behavior preserved by adding secretref alongside configmapref
 - kubectl/helm paths both updated

Include IPRanges change updated.
 - mediator.yaml made into template
 - mediator.yaml added to .gitignore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/147)
<!-- Reviewable:end -->
