### PR TITLE
Updata util kafka client to one that still exists

### DIFF
--- a/images/util/Dockerfile
+++ b/images/util/Dockerfile
@@ -3,7 +3,7 @@ FROM gameontext/docker-liberty-custom:master-14
 LABEL maintainer="Erin Schnabel <schnabel@us.ibm.com> (@ebullientworks)"
 
 ENV SCALA_VERSION 2.12
-ENV KAFKA_VERSION 0.10.2.2
+ENV KAFKA_VERSION 2.3.0
 ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ENV PATH="${KAFKA_HOME}/bin:${PATH}"
 ENV TGZ=kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz


### PR DESCRIPTION
kafka 0.10.2.2 is no longer hosted on the apache mirrors.. 
moving the util image up to the current release 2.3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/148)
<!-- Reviewable:end -->
