### PR TITLE
K8S version compat updates / v3 ext fixes

### DIFF
--- a/bin/gen-certificate.sh
+++ b/bin/gen-certificate.sh
@@ -25,12 +25,17 @@ fi
 ALT=
 j=1
 for x in $@; do
-  echo $x
-  ALT="$ALT\nDNS.${j} = ${x}"
-  ((j++))
+  if [[ $x =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    echo Not adding $x as DNS
+  else
+    echo Adding $x as DNS
+    ALT="$ALT"$'\n'"DNS.${j} = ${x}"
+    ((j++))
+  fi
 done
 if [[ $hostName =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-  ALT="$ALT\nIP.${j} = ${hostName}"
+  echo Adding $hostName as IP
+  ALT="$ALT"$'\n'"IP.${j} = ${hostName}"
 fi
 
 mkdir -p ${targetDir}/.gameontext.openssl > /dev/null 2>&1

--- a/kubernetes/chart/gameon-system/templates/couchdb.yaml
+++ b/kubernetes/chart/gameon-system/templates/couchdb.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     app: {{ .Chart.Name}}-couchdb
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: couchdb-deploy
@@ -24,6 +24,10 @@ metadata:
     app: {{ .Chart.Name}}-couchdb
     {{- include "gameon-system.labels" . }}
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $.Chart.Name }}-couchdb
   strategy:
     type: Recreate
   template:

--- a/kubernetes/chart/gameon-system/templates/kafka.yaml
+++ b/kubernetes/chart/gameon-system/templates/kafka.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     app: {{ .Chart.Name }}-kafka
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-deploy
@@ -24,6 +24,10 @@ metadata:
     app: {{ .Chart.Name }}-kafka
     {{- include "gameon-system.labels" . }}
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $.Chart.Name }}-kafka
   strategy:
     type: Recreate
   template:

--- a/kubernetes/kubectl/auth.yaml
+++ b/kubernetes/kubectl/auth.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-auth
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: auth-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-auth
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-auth
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/couchdb.yaml
+++ b/kubernetes/kubectl/couchdb.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: gameon-couchdb
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: couchdb-deploy
@@ -22,6 +22,7 @@ metadata:
   labels:
     app: gameon-couchdb
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: gameon-couchdb

--- a/kubernetes/kubectl/kafka.yaml
+++ b/kubernetes/kubectl/kafka.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka
   namespace: gameon-system
   labels:
-    app: gameon
+    app: gameon-kafka
 spec:
   type: ClusterIP
   ports:
@@ -14,7 +14,7 @@ spec:
   selector:
     app: gameon-kafka
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kafka-deploy
@@ -22,6 +22,10 @@ metadata:
   labels:
     app: gameon-kafka
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-kafka
   strategy:
     type: Recreate
   template:

--- a/kubernetes/kubectl/map.yaml
+++ b/kubernetes/kubectl/map.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-map
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: map-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-map
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-map
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/mediator.yaml
+++ b/kubernetes/kubectl/mediator.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-mediator
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mediator-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-mediator
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-mediator
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/player.yaml
+++ b/kubernetes/kubectl/player.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-player
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: player-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-player
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-player
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/room.yaml
+++ b/kubernetes/kubectl/room.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-room
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: room-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-room
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-room
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/swagger.yaml
+++ b/kubernetes/kubectl/swagger.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-swagger
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: swagger-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-swagger
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-swagger
   template:
     metadata:
       labels:

--- a/kubernetes/kubectl/webapp.yaml
+++ b/kubernetes/kubectl/webapp.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     app: gameon-webapp
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webapp-deploy
@@ -21,6 +21,10 @@ metadata:
   labels:
     app: gameon-webapp
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gameon-webapp
   template:
     metadata:
       labels:


### PR DESCRIPTION
A few simple changes to update our charts & yamls to work with newer K8S installs. 
Mostly migrating off the extensions/v1beta1 to apps/v1
Adding replicas 1, and a label selector for each deployment.

.. 

Adds fixes for v3.ext generation, linefeeds were being concatted literally, and ip addresses were being added in the alt_names section via DNS= keys. This wasn't an issue before because nginx/haproxy would serve whatever you gave them, but now ingress controllers (and browsers) are a little more picky about what's correct for a cert. Ingress in minikube rejected the cert with the \n's outright, and once fixed, firefox gave misleading errors until the ip address was removed from the DNS section.

..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon/150)
<!-- Reviewable:end -->
